### PR TITLE
Add Coveralls.io code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See Godoc for [automatically generated API documentation](http://godoc.org/githu
 ## Status
 
 [![Build Status](https://drone.io/github.com/emicklei/go-restful/status.png)](https://drone.io/github.com/emicklei/go-restful/latest)
-[![Coverage Status](https://coveralls.io/repos/jmcvetta/go-restful/badge.png?branch=master)](https://coveralls.io/r/jmcvetta/go-restful?branch=master)
+[![Coverage Status](https://coveralls.io/repos/emicklei/go-restful/badge.png?branch=master)](https://coveralls.io/r/emicklei/go-restful?branch=master)
 
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 go-restful
 ==========
 
-package for building REST-style Web Services using Google Go
+`go-restful` is a package for building REST-style Web Services using Google Go.
 
 REST asks developers to use HTTP methods explicitly and in a way that's consistent with the protocol definition. This basic REST design principle establishes a one-to-one mapping between create, read, update, and delete (CRUD) operations and HTTP methods. According to this mapping:
 
@@ -12,15 +12,25 @@ REST asks developers to use HTTP methods explicitly and in a way that's consiste
 - Update = POST if you are requesting the server to update one or more subordinates of the specified resource.
 - Delete = DELETE if you are requesting the server to delete the resource
     
-### Resources
 
-- [Documentation go-restful (godoc.org)](http://godoc.org/github.com/emicklei/go-restful)
+## Documentation
+
+See Godoc for [automatically generated API documentation](http://godoc.org/github.com/emicklei/go-restful).
+
+
+## Status
+
+[![Build Status](https://drone.io/github.com/emicklei/go-restful/status.png)](https://drone.io/github.com/emicklei/go-restful/latest)
+[![Coverage Status](https://coveralls.io/repos/jmcvetta/go-restful/badge.png?branch=master)](https://coveralls.io/r/jmcvetta/go-restful?branch=master)
+
+
+## Resources
+
 - [Hello world, plain and simple](https://github.com/emicklei/go-restful/tree/master/examples/restful-hello-world.go)  
 - [Full API of a UserService](https://github.com/emicklei/go-restful/tree/master/examples/restful-user-service.go) 
 - [Example posted on blog](http://ernestmicklei.com/2012/11/24/go-restful-first-working-example/)
 - [Design explained on blog](http://ernestmicklei.com/2012/11/11/go-restful-api-design/)
 - [Showcase: Landskape tool](https://github.com/emicklei/landskape)
 
-[![Build Status](https://drone.io/github.com/emicklei/go-restful/status.png)](https://drone.io/github.com/emicklei/go-restful/latest)
 
 (c) 2012+, http://ernestmicklei.com. MIT License


### PR DESCRIPTION
This PR adds a [Coveralls](http://coveralls.io) code coverage badge.  

For this to work you will need to:
- Create a Coveralls account (free, trivially easy).
- Add `go-restful` to Coveralls (trivially easy).
- Update Drone.io build settings to match [this example](https://drone.io/github.com/jmcvetta/go-restful/admin), making sure to set up a `COVERALLS_TOKEN` environment variable.  Full instructions can be found at the [goveralls ](https://github.com/mattn/goveralls#droneio) project.