### PR TITLE
Fix missing accept header

### DIFF
--- a/jsr311.go
+++ b/jsr311.go
@@ -41,6 +41,9 @@ func detectRoute(routes []Route, httpWriter http.ResponseWriter, httpRequest *ht
 	// accept
 	outputMediaOk := []Route{}
 	accept := httpRequest.Header.Get(HEADER_Accept)
+	if accept == "" {
+		accept = "*/*"
+	}
 	for _, each := range inputMediaOk {
 		if each.matchesAccept(accept) {
 			outputMediaOk = append(outputMediaOk, each)


### PR DESCRIPTION
Set accept to _/_ if no Accept header was sent

Currently, if the "Accept:" header is omitted in a request, an HTTP 406 Not Acceptable error is generated. However, response.go:42 indicates that an empty Accept header should be treated as if "_/_" was given.
