### PR TITLE
Fixed content-type check in request.go

### DIFF
--- a/request.go
+++ b/request.go
@@ -25,13 +25,16 @@ func (r *Request) QueryParameter(name string) string {
 
 // ReadEntity check the Accept header and reads the content into the entityReference
 func (r *Request) ReadEntity(entityReference interface{}) error {
+	var isXML, isJSON bool
 	contentType := r.Request.Header.Get(HEADER_ContentType)
 	defer r.Request.Body.Close()
 	buffer, err := ioutil.ReadAll(r.Request.Body)
-	if err == nil && MIME_XML == contentType {
+	isXML, err = regexp.MatchString(MIME_XML, contentType)
+	isJSON, err = regexp.MatchString(MIME_JSON, contentType)
+	if err == nil && isXML {
 		err = xml.Unmarshal(buffer, entityReference)
 	} else {
-		if err == nil && MIME_JSON == contentType {
+		if err == nil && isJSON {
 			err = json.Unmarshal(buffer, entityReference)
 		}
 	}


### PR DESCRIPTION
Content-Type may have ";charset=utf-8" to denotate the encoding and
in this cases, request.go was failing to determine the content-type.
