### PR TITLE
Fix PathParameters for WebService filter

### DIFF
--- a/route.go
+++ b/route.go
@@ -37,12 +37,17 @@ func (self *Route) postBuild() {
 	self.pathParts = tokenizePath(self.Path)
 }
 
-// Extract any path parameters from the the request URL path and call the function
-func (self *Route) dispatch(httpWriter http.ResponseWriter, httpRequest *http.Request) {
+// Create Request and Response from their http versions
+func (self *Route) wrapRequestResponse(httpWriter http.ResponseWriter, httpRequest *http.Request) (*Request, *Response) {
 	params := self.extractParameters(httpRequest.URL.Path)
 	accept := httpRequest.Header.Get(HEADER_Accept)
 	wrappedRequest := &Request{httpRequest, params}
 	wrappedResponse := &Response{httpWriter, accept, self.Produces}
+	return wrappedRequest, wrappedResponse
+}
+
+// Extract any path parameters from the the request URL path and call the function
+func (self *Route) dispatch(wrappedRequest *Request, wrappedResponse *Response) {
 	if len(self.Filters) > 0 {
 		chain := FilterChain{Filters: self.Filters, Target: self.Function}
 		chain.ProcessFilter(wrappedRequest, wrappedResponse)

--- a/web_service_container.go
+++ b/web_service_container.go
@@ -111,16 +111,16 @@ func DefaultDispatch(httpWriter http.ResponseWriter, httpRequest *http.Request) 
 	if detected {
 		// pass through filters (if any)
 		filters := dispatcher.filters
+		wrappedRequest, wrappedResponse := route.wrapRequestResponse(httpWriter, httpRequest)
 		if len(filters) > 0 {
-			wrappedRequest, wrappedResponse := newBasicRequestResponse(httpWriter, httpRequest)
 			chain := FilterChain{Filters: filters, Target: func(req *Request, resp *Response) {
 				// handle request by route
-				route.dispatch(resp, req.Request)
+				route.dispatch(wrappedRequest, wrappedResponse)
 			}}
 			chain.ProcessFilter(wrappedRequest, wrappedResponse)
 		} else {
 			// handle request by route
-			route.dispatch(httpWriter, httpRequest)
+			route.dispatch(wrappedRequest, wrappedResponse)
 		}
 	}
 	// else a non-200 response has already been written


### PR DESCRIPTION
Previously, filters defined for WebServices used their own means of
wrapping http.ResponseWriter and http.Request. This lead to
req.PathParameters returning no parameters. This commit applies the
usual wrapping as defined in route.go when calling WebService filters.
