### PR TITLE
Add HTTP PATCH Method

### DIFF
--- a/web_service.go
+++ b/web_service.go
@@ -121,6 +121,11 @@ func (w *WebService) PUT(subPath string) *RouteBuilder {
 	return new(RouteBuilder).servicePath(w.rootPath).Method("PUT").Path(subPath)
 }
 
+// PATCH is a shortcut for .Method("PATCH").Path(subPath)
+func (w *WebService) PATCH(subPath string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method("PATCH").Path(subPath)
+}
+
 // DELETE is a shortcut for .Method("DELETE").Path(subPath)
 func (w *WebService) DELETE(subPath string) *RouteBuilder {
 	return new(RouteBuilder).servicePath(w.rootPath).Method("DELETE").Path(subPath)


### PR DESCRIPTION
Quoting the abstract of [RFC 5789](https://tools.ietf.org/html/rfc5789):

> Several applications extending the Hypertext Transfer Protocol (HTTP)
> require a feature to do partial resource modification.  The existing
> HTTP PUT method only allows a complete replacement of a document.
> This proposal adds a new HTTP method, PATCH, to modify an existing
> HTTP resource.
