### PR TITLE
Handle swagger “required” properly.

### DIFF
--- a/swagger/model_builder.go
+++ b/swagger/model_builder.go
@@ -29,7 +29,7 @@ func (b modelBuilder) addModel(st reflect.Type) {
 			jsonName := sf.Name
 			sft := sf.Type
 			prop := ModelProperty{}
-
+			required := true
 			// see if a tag overrides this
 			if jsonTag := st.Field(i).Tag.Get("json"); jsonTag != "" {
 				s := strings.Split(jsonTag, ",")
@@ -45,10 +45,13 @@ func (b modelBuilder) addModel(st reflect.Type) {
 						sft = reflect.TypeOf("")
 					case "omitempty":
 						//todo: handle this case?
+						required = false
 					}
 				}
 			}
-
+			if required {
+				sm.Required = append(sm.Required, jsonName)
+			}
 			prop.Type = sft.String() // include pkg path
 			// override type of list-likes
 			if sft.Kind() == reflect.Slice || sft.Kind() == reflect.Array {
@@ -71,9 +74,11 @@ func (b modelBuilder) addModel(st reflect.Type) {
 				}
 			}
 			sm.Properties[jsonName] = prop
-			//log.Printf("%s=%#v", jsonName, prop)
 		}
 	}
+
+	// update model builder with completed model
+	b.Models[modelName] = sm
 }
 
 func (b modelBuilder) keyFrom(st reflect.Type) string {

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -19,7 +19,12 @@ func TestJsonTags(t *testing.T) {
 
 	expected := `{
   "id": "swagger.X",
-  "required": [],
+  "required": [
+   "A",
+   "C",
+   "E",
+   "I"
+  ],
   "properties": {
    "A": {
     "type": "string",
@@ -48,14 +53,10 @@ func TestJsonTags(t *testing.T) {
   }
  }`
 
-	_ = expected
 	sws := newSwaggerService(Config{})
 	decl := ApiDeclaration{Models: map[string]Model{}}
 	sws.addModelFromSampleTo(&Operation{}, true, X{}, &decl)
 
-	properties := decl.Models["swagger.X"].Properties
-	_, ok := properties[""]
-	_ = ok
 	output, _ := json.MarshalIndent(decl.Models["swagger.X"], " ", " ")
 	if string(output) != expected {
 		t.Error("output != expected")

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -76,7 +76,7 @@ type ErrorResponse struct {
 
 type Model struct {
 	Id         string                   `json:"id"`
-	Required   []string                 `json:"required"`
+	Required   []string                 `json:"required,omitempty"`
 	Properties map[string]ModelProperty `json:"properties"`
 }
 


### PR DESCRIPTION
Don’t emit required if its empty, add all elements not tagged omitempty to required. Second try (see #89), should fix the problem with recursive models in the previous pull req. (I dont see an easy way around the double assign to the model builder, without it I think the slice needs to be a pointer?)
