### PR TITLE
Support for anonymous structs.

### DIFF
--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -2,65 +2,260 @@ package swagger
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 )
 
 func TestJsonTags(t *testing.T) {
 	type X struct {
 		A string
-		B string `json:"C"`
-		D string `json:"-"`
-		E int    `json:",string"`
-		F int    `json:",omitempty"`
-		G int    `json:"H,omitempty"`
-		I int    `json:","`
+		B string `json:"-"`
+		C int    `json:",string"`
+		D int    `json:","`
 	}
 
 	expected := `{
-  "id": "swagger.X",
-  "required": [
-   "A",
-   "C",
-   "E",
-   "I"
-  ],
-  "properties": {
-   "A": {
-    "type": "string",
-    "description": ""
-   },
-   "C": {
-    "type": "string",
-    "description": ""
-   },
-   "E": {
-    "type": "string",
-    "description": "(int as string)"
-   },
-   "F": {
-    "type": "int",
-    "description": ""
-   },
-   "H": {
-    "type": "int",
-    "description": ""
-   },
-   "I": {
-    "type": "int",
-    "description": ""
+  "swagger.X": {
+   "id": "swagger.X",
+   "required": [
+    "A",
+    "C",
+    "D"
+   ],
+   "properties": {
+    "A": {
+     "type": "string",
+     "description": ""
+    },
+    "C": {
+     "type": "string",
+     "description": "(int as string)"
+    },
+    "D": {
+     "type": "int",
+     "description": ""
+    }
    }
   }
  }`
 
+	testJsonFromStruct(t, X{}, expected)
+}
+
+func TestJsonTagOmitempty(t *testing.T) {
+	type X struct {
+		A int `json:",omitempty"`
+		B int `json:"C,omitempty"`
+	}
+
+	expected := `{
+  "swagger.X": {
+   "id": "swagger.X",
+   "properties": {
+    "A": {
+     "type": "int",
+     "description": ""
+    },
+    "C": {
+     "type": "int",
+     "description": ""
+    }
+   }
+  }
+ }`
+
+	testJsonFromStruct(t, X{}, expected)
+}
+
+func TestJsonTagName(t *testing.T) {
+	type X struct {
+		A string `json:"B"`
+	}
+
+	expected := `{
+  "swagger.X": {
+   "id": "swagger.X",
+   "required": [
+    "B"
+   ],
+   "properties": {
+    "B": {
+     "type": "string",
+     "description": ""
+    }
+   }
+  }
+ }`
+
+	testJsonFromStruct(t, X{}, expected)
+}
+
+func TestAnonymousStruct(t *testing.T) {
+	type X struct {
+		A struct {
+			B int
+		}
+	}
+
+	expected := `{
+  "swagger.X": {
+   "id": "swagger.X",
+   "required": [
+    "A"
+   ],
+   "properties": {
+    "A": {
+     "type": "swagger.X.A",
+     "description": ""
+    }
+   }
+  },
+  "swagger.X.A": {
+   "id": "swagger.X.A",
+   "required": [
+    "B"
+   ],
+   "properties": {
+    "B": {
+     "type": "int",
+     "description": ""
+    }
+   }
+  }
+ }`
+
+	testJsonFromStruct(t, X{}, expected)
+}
+
+func TestAnonymousPtrStruct(t *testing.T) {
+	type X struct {
+		A *struct {
+			B int
+		}
+	}
+
+	expected := `{
+  "swagger.X": {
+   "id": "swagger.X",
+   "required": [
+    "A"
+   ],
+   "properties": {
+    "A": {
+     "type": "swagger.X.A",
+     "description": ""
+    }
+   }
+  },
+  "swagger.X.A": {
+   "id": "swagger.X.A",
+   "required": [
+    "B"
+   ],
+   "properties": {
+    "B": {
+     "type": "int",
+     "description": ""
+    }
+   }
+  }
+ }`
+
+	testJsonFromStruct(t, X{}, expected)
+}
+
+func TestAnonymousArrayStruct(t *testing.T) {
+	type X struct {
+		A []struct {
+			B int
+		}
+	}
+
+	expected := `{
+  "swagger.X": {
+   "id": "swagger.X",
+   "required": [
+    "A"
+   ],
+   "properties": {
+    "A": {
+     "type": "array",
+     "description": "",
+     "items": {
+      "$ref": "swagger.X.A"
+     }
+    }
+   }
+  },
+  "swagger.X.A": {
+   "id": "swagger.X.A",
+   "required": [
+    "B"
+   ],
+   "properties": {
+    "B": {
+     "type": "int",
+     "description": ""
+    }
+   }
+  }
+ }`
+
+	testJsonFromStruct(t, X{}, expected)
+}
+
+func TestAnonymousPtrArrayStruct(t *testing.T) {
+	type X struct {
+		A *[]struct {
+			B int
+		}
+	}
+
+	expected := `{
+  "swagger.X": {
+   "id": "swagger.X",
+   "required": [
+    "A"
+   ],
+   "properties": {
+    "A": {
+     "type": "array",
+     "description": "",
+     "items": {
+      "$ref": "swagger.X.A"
+     }
+    }
+   }
+  },
+  "swagger.X.A": {
+   "id": "swagger.X.A",
+   "required": [
+    "B"
+   ],
+   "properties": {
+    "B": {
+     "type": "int",
+     "description": ""
+    }
+   }
+  }
+ }`
+
+	testJsonFromStruct(t, X{}, expected)
+}
+
+func jsonFromSwaggerService(sample interface{}) string {
 	sws := newSwaggerService(Config{})
 	decl := ApiDeclaration{Models: map[string]Model{}}
-	sws.addModelFromSampleTo(&Operation{}, true, X{}, &decl)
+	sws.addModelFromSampleTo(&Operation{}, true, sample, &decl)
 
-	output, _ := json.MarshalIndent(decl.Models["swagger.X"], " ", " ")
-	if string(output) != expected {
-		t.Error("output != expected")
-		os.Stdout.WriteString(expected)
+	output, _ := json.MarshalIndent(decl.Models, " ", " ")
+	return string(output)
+}
+
+func testJsonFromStruct(t *testing.T, sample interface{}, expectedJson string) {
+	output := jsonFromSwaggerService(sample)
+	if output != expectedJson {
+		t.Error("output != expected\nexpected:", expectedJson)
 	}
-	os.Stdout.Write(output)
+	t.Log("output:\n", output)
 }

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -198,7 +198,7 @@ func (sws SwaggerService) addModelFromSampleTo(operation *Operation, isResponse 
 		}
 		operation.Type = modelName
 	}
-	modelBuilder{decl.Models}.addModel(reflect.TypeOf(sample))
+	modelBuilder{decl.Models}.addModel(reflect.TypeOf(sample), "")
 }
 
 func asSwaggerParameter(param restful.ParameterData) Parameter {


### PR DESCRIPTION
This PR will add support for anonymous structs in swagger output. (`struct {}`, `*struct {}`, `[]struct {}`, and `*[]struct{}` are handled). See #78 for more details.
