### PR TITLE
Add form type for Swagger

### DIFF
--- a/parameter.go
+++ b/parameter.go
@@ -9,6 +9,7 @@ const (
 	QUERY_PARAMETER         // indicator of Request parameter type "query"
 	BODY_PARAMETER          // indicator of Request parameter type "body"
 	HEADER_PARAMETER        // indicator of Request parameter type "header"
+	FORM_PARAMETER          // indicator of Request parameter type "form"
 )
 
 // Parameter is for documententing the parameter used in a Http Request
@@ -52,6 +53,11 @@ func (p *Parameter) beBody() *Parameter {
 
 func (p *Parameter) beHeader() *Parameter {
 	p.data.Kind = HEADER_PARAMETER
+	return p
+}
+
+func (p *Parameter) beForm() *Parameter {
+	p.data.Kind = FORM_PARAMETER
 	return p
 }
 

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -261,6 +261,8 @@ func asParamType(kind int) string {
 		return "body"
 	case kind == restful.HEADER_PARAMETER:
 		return "header"
+	case kind == restful.FORM_PARAMETER:
+		return "form"
 	}
 	return ""
 }

--- a/web_service.go
+++ b/web_service.go
@@ -73,6 +73,14 @@ func (w *WebService) HeaderParameter(name, description string) *Parameter {
 	return p
 }
 
+// FormParameter creates a new Parameter of kind Form (using application/x-www-form-urlencoded) for documentation purposes.
+// It is initialized as required with string as its DataType.
+func (w *WebService) FormParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string"}}
+	p.beForm()
+	return p
+}
+
 // Route creates a new Route using the RouteBuilder and add to the ordered list of Routes.
 func (w *WebService) Route(builder *RouteBuilder) *WebService {
 	builder.copyDefaults(w.produces, w.consumes)


### PR DESCRIPTION
Swagger supports a form type that can be a multipart form or a urlencoded query in the body. This plumbs that support through go-restful.
