### PR TITLE
Moving newResponse to public interface

### DIFF
--- a/container.go
+++ b/container.go
@@ -180,7 +180,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 			// handle err here
 
 		}}
-		chain.ProcessFilter(newRequest(httpRequest), newResponse(writer))
+		chain.ProcessFilter(newRequest(httpRequest), NewResponse(writer))
 		return
 	}
 	wrappedRequest, wrappedResponse := route.wrapRequestResponse(writer, httpRequest)
@@ -259,7 +259,7 @@ func (c Container) computeAllowedMethods(req *Request) []string {
 // newBasicRequestResponse creates a pair of Request,Response from its http versions.
 // It is basic because no parameter or (produces) content-type information is given.
 func newBasicRequestResponse(httpWriter http.ResponseWriter, httpRequest *http.Request) (*Request, *Response) {
-	resp := newResponse(httpWriter)
+	resp := NewResponse(httpWriter)
 	resp.requestAccept = httpRequest.Header.Get(HEADER_Accept)
 	return newRequest(httpRequest), resp
 }

--- a/response.go
+++ b/response.go
@@ -28,7 +28,8 @@ type Response struct {
 	contentLength int      // number of bytes written for the response body
 }
 
-func newResponse(httpWriter http.ResponseWriter) *Response {
+// Creates a new response based on a http ResponseWriter.
+func NewResponse(httpWriter http.ResponseWriter) *Response {
 	return &Response{httpWriter, "", []string{}, http.StatusOK, 0} // empty content-types
 }
 

--- a/route.go
+++ b/route.go
@@ -44,7 +44,7 @@ func (r *Route) wrapRequestResponse(httpWriter http.ResponseWriter, httpRequest 
 	wrappedRequest := newRequest(httpRequest)
 	wrappedRequest.pathParameters = params
 	wrappedRequest.selectedRoutePath = r.Path
-	wrappedResponse := newResponse(httpWriter)
+	wrappedResponse := NewResponse(httpWriter)
 	wrappedResponse.requestAccept = httpRequest.Header.Get(HEADER_Accept)
 	wrappedResponse.routeProduces = r.Produces
 	return wrappedRequest, wrappedResponse


### PR DESCRIPTION
I need a middleware filter to pass down a different ResponseWriter, so I need a way to construct a restful.Response. The best way I've found to do this is to expose the newResponse function as public. 
