### PR TITLE
Removed trailing slash when the route path is empty

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -148,5 +148,5 @@ func (b *RouteBuilder) Build() Route {
 }
 
 func concatPath(path1, path2 string) string {
-	return strings.TrimRight(path1, "/") + "/" + strings.TrimLeft(path2, "/")
+	return strings.TrimRight( strings.TrimRight(path1, "/") + "/" + strings.TrimLeft(path2, "/") )
 }


### PR DESCRIPTION
ws.POST("") for example will produce a path like /rootpath/

Note the trailing slash. It should be /rootpath
