### PR TITLE
Return 404 when no routes are matched

### DIFF
--- a/jsr311.go
+++ b/jsr311.go
@@ -31,6 +31,9 @@ func (r RouterJSR311) SelectRoute(
 	}
 	// Obtain the set of candidate methods (Routes)
 	routes := r.selectRoutes(dispatcher, finalMatch)
+	if len(routes) == 0 {
+		return dispatcher, nil, NewError(http.StatusNotFound, "404: Page Not Found")
+	}
 
 	// Identify the method (Route) that will handle the request
 	route, ok := r.detectRoute(routes, httpRequest)


### PR DESCRIPTION
Previously it was returning 405, Method Not Allowed.
