### PR TITLE
Replace "constants.go#toCommaseparated" with "strings.Join"

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -4,8 +4,6 @@ package restful
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
 
-import "bytes"
-
 const (
 	MIME_XML  = "application/xml"  // Accept or Content-Type used in Consumes() and/or Produces()
 	MIME_JSON = "application/json" // Accept or Content-Type used in Consumes() and/or Produces()
@@ -28,14 +26,3 @@ const (
 	ENCODING_GZIP    = "gzip"
 	ENCODING_DEFLATE = "deflate"
 )
-
-func toCommaSeparated(names []string) string {
-	buf := new(bytes.Buffer)
-	for _, each := range names {
-		if buf.Len() > 0 {
-			buf.WriteString(",")
-		}
-		buf.WriteString(each)
-	}
-	return buf.String()
-}

--- a/cors_filter.go
+++ b/cors_filter.go
@@ -40,7 +40,7 @@ func (c CrossOriginResourceSharing) Filter(req *Request, resp *Response, chain *
 }
 
 func (c CrossOriginResourceSharing) doActualRequest(req *Request, resp *Response, chain *FilterChain) {
-	resp.AddHeader(HEADER_AccessControlExposeHeaders, toCommaSeparated(c.AllowedHeaders))
+	resp.AddHeader(HEADER_AccessControlExposeHeaders, strings.Join(c.AllowedHeaders, ","))
 	c.checkAndSetExposeHeaders(resp)
 	c.setAllowOriginHeader(req, resp)
 	c.checkAndSetAllowCredentials(resp)
@@ -63,7 +63,7 @@ func (c CrossOriginResourceSharing) doPreflightRequest(req *Request, resp *Respo
 			}
 		}
 	}
-	resp.AddHeader(HEADER_AccessControlAllowMethods, toCommaSeparated(allowedMethods))
+	resp.AddHeader(HEADER_AccessControlAllowMethods, strings.Join(allowedMethods, ","))
 	resp.AddHeader(HEADER_AccessControlAllowHeaders, acrhs)
 	c.setAllowOriginHeader(req, resp)
 	c.checkAndSetAllowCredentials(resp)
@@ -96,7 +96,7 @@ func (c CrossOriginResourceSharing) setAllowOriginHeader(req *Request, resp *Res
 
 func (c CrossOriginResourceSharing) checkAndSetExposeHeaders(resp *Response) {
 	if len(c.ExposeHeaders) > 0 {
-		resp.AddHeader(HEADER_AccessControlExposeHeaders, toCommaSeparated(c.ExposeHeaders))
+		resp.AddHeader(HEADER_AccessControlExposeHeaders, strings.Join(c.ExposeHeaders, ","))
 	}
 }
 

--- a/options_filter.go
+++ b/options_filter.go
@@ -1,5 +1,7 @@
 package restful
 
+import "strings"
+
 // Copyright 2013 Ernest Micklei. All rights reserved.
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
@@ -12,7 +14,7 @@ func (c Container) OPTIONSFilter(req *Request, resp *Response, chain *FilterChai
 		chain.ProcessFilter(req, resp)
 		return
 	}
-	resp.AddHeader(HEADER_Allow, toCommaSeparated(c.computeAllowedMethods(req)))
+	resp.AddHeader(HEADER_Allow, strings.Join(c.computeAllowedMethods(req), ","))
 }
 
 // OPTIONSFilter is a filter function that inspects the Http Request for the OPTIONS method


### PR DESCRIPTION
I've noticed you've used a handmade function to join strings with separator, so i've replaced it with standard strings.Join. Test still pass.
