### PR TITLE
Skip examples dir in Sourcegraph/srclib build

### DIFF
--- a/Srcfile
+++ b/Srcfile
@@ -1,0 +1,1 @@
+{"SkipDirs": ["examples"]}


### PR DESCRIPTION
The examples dir contains multiple main packages, which do not build as a Go package. This SkipDirs directive means that Sourcegraph/srclib will skip these directories in the build.

This means that go-restful builds will pass. Previously we had been making a special exception for `github.com/emicklei/go-restful` (see the top of [overrides.go](https://sourcegraph.com/github.com/sourcegraph/srclib@master/.tree/config/overrides.go)), but that doesn't apply to forks. Using a Srcfile to exclude the examples dir means that forks will build successfully, so you can view cross-repo pull request diffs (see the below screenshot or https://sourcegraph.com/github.com/fsouza/go-dockerclient/.pulls/133 for an example).

A Srcfile is the config file for [srclib](https://srclib.org), which is the open-source code analysis lib that powers Sourcegraph. There are also lots of editor plugins and some other tools for srclib, so using a Srcfile means go-restful will also work correctly in all of those plugins/tools. (It's not just something Sourcegraph-specific.)

Thanks!

![image](https://cloud.githubusercontent.com/assets/1976/4314607/e96f511c-3ee2-11e4-9222-522b7da9f99a.png)
