### PR TITLE
make compilePathExpression threadsafe

### DIFF
--- a/web_service.go
+++ b/web_service.go
@@ -10,19 +10,23 @@ import (
 
 // WebService holds a collection of Route values that bind a Http Method + URL Path to a function.
 type WebService struct {
-	rootPath       string
-	pathExpr       *pathExpression // cached compilation of rootPath as RegExp
-	routes         []Route
-	produces       []string
-	consumes       []string
-	pathParameters []*Parameter
-	filters        []FilterFunction
-	documentation  string
-	apiVersion     string
+	rootPath         string
+	pathExpr         *pathExpression // cached compilation of rootPath as RegExp
+	routes           []Route
+	produces         []string
+	consumes         []string
+	pathParameters   []*Parameter
+	filters          []FilterFunction
+	documentation    string
+	apiVersion       string
+	compilationMutex sync.Mutex
 }
 
 // compiledPathExpression ensures that the path is compiled into a RegEx for those routers that need it.
 func (w *WebService) compiledPathExpression() *pathExpression {
+	w.compilationMutex.Lock()
+	defer w.compilationMutex.Unlock()
+
 	if w.pathExpr == nil {
 		if len(w.rootPath) == 0 {
 			w.Path("/") // lazy initialize path


### PR DESCRIPTION
When using go-restful, if we start hitting the rest endpoints during our integration tests, we can see data races like this:  https://gist.github.com/deads2k/9eb5e74e0341904529a2.

By locking the compiledPathExpression method on a per instance basis, the problem can be avoided.  I initially tried a double checked lock, but that still failed with the data race failure.  Based on my read of https://golang.org/doc/articles/race_detector.html, it seems that Thread A gains access to the critical section and does a set.  Meanwhile, Thread B performs the first check and gets "true".  That counts as a read access at the same time as a write access.  At any rate, I couldn't make the normal double checked lock work like this:

```
    if w.pathExpr == nil {
        w.compilationMutex.Lock()
        defer w.compilationMutex.Unlock()
        if w.pathExpr == nil {
```

So I locked the entire thing.  I'm open to any other solution that works.
