### PR TITLE
Swagger items should be object

### DIFF
--- a/swagger/model_builder.go
+++ b/swagger/model_builder.go
@@ -168,8 +168,11 @@ func (b modelBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName
 	var pType = "array"
 	prop.Type = &pType
 	elemName := b.getElementTypeName(modelName, jsonName, fieldType.Elem())
-	prop.Items = []Item{Item{Ref: &elemName}}
+	prop.Items = &Item{Ref: &elemName}
 	// add|overwrite model for element type
+	if fieldType.Elem().Kind() == reflect.Ptr {
+		fieldType = fieldType.Elem()
+	}
 	b.addModel(fieldType.Elem(), elemName)
 	return jsonName, prop
 }
@@ -182,7 +185,7 @@ func (b modelBuilder) buildPointerTypeProperty(field reflect.StructField, jsonNa
 		var pType = "array"
 		prop.Type = &pType
 		elemName := b.getElementTypeName(modelName, jsonName, fieldType.Elem().Elem())
-		prop.Items = []Item{Item{Ref: &elemName}}
+		prop.Items = &Item{Ref: &elemName}
 		// add|overwrite model for element type
 		b.addModel(fieldType.Elem().Elem(), elemName)
 	} else {
@@ -200,6 +203,9 @@ func (b modelBuilder) buildPointerTypeProperty(field reflect.StructField, jsonNa
 }
 
 func (b modelBuilder) getElementTypeName(modelName, jsonName string, t reflect.Type) string {
+	if t.Kind() == reflect.Ptr {
+		return t.String()[1:]
+	}
 	if t.Name() == "" {
 		return modelName + "." + jsonName
 	}

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -95,11 +95,9 @@ func TestS2(t *testing.T) {
    "properties": {
     "Ids": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "string"
-      }
-     ]
+     "items": {
+      "$ref": "string"
+     }
     }
    }
   }
@@ -177,11 +175,9 @@ func TestSampleToModelAsJson(t *testing.T) {
     },
     "items": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "swagger.item"
-      }
-     ]
+     "items": {
+      "$ref": "swagger.item"
+     }
     },
     "root": {
      "type": "swagger.item",
@@ -361,11 +357,9 @@ func TestAnonymousArrayStruct(t *testing.T) {
    "properties": {
     "A": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "swagger.X.A"
-      }
-     ]
+     "items": {
+      "$ref": "swagger.X.A"
+     }
     }
    }
   },
@@ -402,11 +396,9 @@ func TestAnonymousPtrArrayStruct(t *testing.T) {
    "properties": {
     "A": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "swagger.X.A"
-      }
-     ]
+     "items": {
+      "$ref": "swagger.X.A"
+     }
     }
    }
   },
@@ -467,11 +459,9 @@ func TestIssue85(t *testing.T) {
    "properties": {
     "Datasets": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "swagger.Dataset"
-      }
-     ]
+     "items": {
+      "$ref": "swagger.Dataset"
+     }
     }
    }
   },
@@ -483,11 +473,9 @@ func TestIssue85(t *testing.T) {
    "properties": {
     "Names": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "string"
-      }
-     ]
+     "items": {
+      "$ref": "string"
+     }
     }
    }
   }
@@ -511,25 +499,17 @@ func TestRecursiveStructure(t *testing.T) {
    "properties": {
     "History": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "swagger.File"
-      }
-     ]
+     "items": {
+      "$ref": "swagger.File"
+     }
     },
     "HistoryPtrs": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "swagger.File.HistoryPtrs"
-      }
-     ]
+     "items": {
+      "$ref": "swagger.File"
+     }
     }
    }
-  },
-  "swagger.File.HistoryPtrs": {
-   "id": "swagger.File.HistoryPtrs",
-   "properties": {}
   }
  }`)
 }
@@ -669,11 +649,9 @@ func TestRegion_Issue113(t *testing.T) {
    "properties": {
     "id": {
      "type": "array",
-     "items": [
-      {
-       "$ref": "integer"
-      }
-     ]
+     "items": {
+      "$ref": "integer"
+     }
     },
     "name": {
      "type": "string"
@@ -726,4 +704,55 @@ func TestIssue158(t *testing.T) {
   }
  }`
 	testJsonFromStruct(t, Customer{}, expected)
+}
+
+func TestSlices(t *testing.T) {
+	type Address struct {
+		Country string `json:"country,omitempty"`
+
+	}
+	expected := `{
+  "swagger.Address": {
+   "id": "swagger.Address",
+   "properties": {
+    "country": {
+     "type": "string"
+    }
+   }
+  },
+  "swagger.Customer": {
+   "id": "swagger.Customer",
+   "required": [
+    "name",
+    "addresses"
+   ],
+   "properties": {
+    "addresses": {
+     "type": "array",
+     "items": {
+      "$ref": "swagger.Address"
+     }
+    },
+    "name": {
+     "type": "string"
+    }
+   }
+  }
+ }`
+	// both slices (with pointer value and with type value) should have equal swagger representation
+	{
+		type Customer struct {
+			Name    string  `json:"name"`
+			Addresses []Address `json:"addresses"`
+		}
+		testJsonFromStruct(t, Customer{}, expected)
+	}
+	{
+		type Customer struct {
+			Name    string  `json:"name"`
+			Addresses []*Address `json:"addresses"`
+		}
+		testJsonFromStruct(t, Customer{}, expected)
+	}
+
 }

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -13,7 +13,7 @@ type DataTypeFields struct {
 	Enum         []string `json:"enum,omitempty"`
 	Minimum      string   `json:"minimum,omitempty"`
 	Maximum      string   `json:"maximum,omitempty"`
-	Items        []Item   `json:"items,omitempty"`
+	Items        *Item   `json:"items,omitempty"`
 	UniqueItems  *bool    `json:"uniqueItems,omitempty"`
 }
 

--- a/swagger/swagger_test.go
+++ b/swagger/swagger_test.go
@@ -103,10 +103,10 @@ func TestIssue78(t *testing.T) {
 		t.Fatal("wrong items type:" + *items.Type)
 	}
 	items_items := items.Items
-	if len(items_items) == 0 {
+	if items_items == nil {
 		t.Fatal("missing items->items")
 	}
-	ref := items_items[0].Ref
+	ref := items_items.Ref
 	if ref == nil {
 		t.Fatal("missing $ref")
 	}


### PR DESCRIPTION
According to the documentation https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#434-items-object Items field should be object, not an array.

Also this PR fixes bug with slices, because []Address is equal []*Address in swagger representation