### PR TITLE
Add useful Notes method for swagger

### DIFF
--- a/route.go
+++ b/route.go
@@ -29,6 +29,7 @@ type Route struct {
 
 	// documentation
 	Doc                     string
+	Notes                   string
 	Operation               string
 	ParameterDocs           []*Parameter
 	ResponseErrors          map[int]ResponseError

--- a/route_builder.go
+++ b/route_builder.go
@@ -21,6 +21,7 @@ type RouteBuilder struct {
 	filters     []FilterFunction
 	// documentation
 	doc                     string
+	notes                   string
 	operation               string
 	readSample, writeSample interface{}
 	parameters              []*Parameter
@@ -76,6 +77,12 @@ func (b *RouteBuilder) Path(subPath string) *RouteBuilder {
 // Doc tells what this route is all about. Optional.
 func (b *RouteBuilder) Doc(documentation string) *RouteBuilder {
 	b.doc = documentation
+	return b
+}
+
+// A verbose explanation of the operation behavior. Optional.
+func (b *RouteBuilder) Notes(notes string) *RouteBuilder {
+	b.notes = notes
 	return b
 }
 
@@ -194,6 +201,7 @@ func (b *RouteBuilder) Build() Route {
 		relativePath:   b.currentPath,
 		pathExpr:       pathExpr,
 		Doc:            b.doc,
+		Notes:          b.notes,
 		Operation:      b.operation,
 		ParameterDocs:  b.parameters,
 		ResponseErrors: b.errorMap,

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -193,6 +193,7 @@ func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix 
 			operation := Operation{
 				Method:           route.Method,
 				Summary:          route.Doc,
+				Notes:            route.Notes,
 				Type:             asDataType(route.WriteSample),
 				Parameters:       []Parameter{},
 				Nickname:         route.Operation,


### PR DESCRIPTION
It's very often required to add extra information about api endpoint. According to the swagger spec [0] Notes field is a verbose explanation of the operation behavior.

[0] https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#523-operation-object