### PR TITLE
Allow customizing rendering of ServiceErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 - Automatic CORS request handling (using a filter)
 - API declaration for Swagger UI (see swagger package)
 - Panic recovery to produce HTTP 500, customizable using RecoverHandler(...)
+- Route errors produce HTTP 404/405/406/415 errors, customizable using ServiceErrorHandler(...)
 	
 ### Resources
 


### PR DESCRIPTION
Adds `ServiceErrorHandler` to allow custom rendering of ServiceError objects. This is useful when a server wants 404/405/406/415 errors to be rendered in a specific way consumable by API clients, rather than just as status codes and plain text messages.