### PR TITLE
In routefunction_test, use Fatalf instead of Logf.

### DIFF
--- a/examples/restful-routefunction_test.go
+++ b/examples/restful-routefunction_test.go
@@ -24,6 +24,6 @@ func TestCallFunction(t *testing.T) {
 
 	getIt(req, resp)
 	if recorder.Code != 404 {
-		t.Logf("Missing or wrong status code:%d", recorder.Code)
+		t.Fatalf("Missing or wrong status code:%d", recorder.Code)
 	}
 }


### PR DESCRIPTION
Logf output is only shown on test failure. With this change, the unit test now fails, and I'm not sure why.