### PR TITLE
Use an interface for Logger instead of concrete type

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,16 +1,32 @@
 package restful
 
-import "log"
-
 // Copyright 2014 Ernest Micklei. All rights reserved.
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
 
 var trace bool = false
-var traceLogger *log.Logger
+var traceLogger Logger
+
+// Logger corresponds to a subset of the interface satisfied by stdlib log.Logger
+type Logger interface {
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Fatalln(v ...interface{})
+	// Flags() int
+	// Output(calldepth int, s string) error
+	// Panic(v ...interface{})
+	// Panicf(format string, v ...interface{})
+	// Panicln(v ...interface{})
+	// Prefix() string
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+	// SetFlags(flag int)
+	// SetPrefix(prefix string)
+}
 
 // TraceLogger enables detailed logging of Http request matching and filter invocation. Default no logger is set.
-func TraceLogger(logger *log.Logger) {
+func TraceLogger(logger Logger) {
 	traceLogger = logger
 	trace = logger != nil
 }


### PR DESCRIPTION
As easy as that. Not really sure how to test this, I guess the type checker does that for us.
I did a quick test with log.Logger and logrus.logger and both work, tests pass as well.

closes #187