### PR TITLE
Add 'log' package for package-wide logging, expose SetLogger(Logger).

### DIFF
--- a/container.go
+++ b/container.go
@@ -7,10 +7,11 @@ package restful
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net/http"
 	"runtime"
 	"strings"
+
+	"github.com/emicklei/go-restful/log"
 )
 
 // Container holds a collection of WebServices and a http.ServeMux to dispatch http requests.

--- a/doc.go
+++ b/doc.go
@@ -165,9 +165,16 @@ If you expect to read large amounts of payload data, and you do not use this fea
 Trouble shooting
 
 This package has the means to produce detail logging of the complete Http request matching process and filter invocation.
-Enabling this feature requires you to set an implementation of restful.Logger (e.g. log.Logger) instance such as:
+Enabling this feature requires you to set an implementation of restful.StdLogger (e.g. log.Logger) instance such as:
 
 	restful.TraceLogger(log.New(os.Stdout, "[restful] ", log.LstdFlags|log.Lshortfile))
+
+Logging
+
+The restful.SetLogger() method allows you to override the logger used by the package. By default restful
+uses the standard library `log` package and logs to stdout. Different logging packages are supported as
+long as they conform to `StdLogger` interface defined in the `log` sub-package, writing an adapter for your
+preferred package is simple.
 
 Resources
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,59 @@
+package log
+
+import (
+	stdlog "log"
+	"os"
+)
+
+// Logger corresponds to a subset of the interface satisfied by stdlib log.Logger
+type StdLogger interface {
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Fatalln(v ...interface{})
+	// Flags() int
+	// Output(calldepth int, s string) error
+	// Panic(v ...interface{})
+	// Panicf(format string, v ...interface{})
+	// Panicln(v ...interface{})
+	// Prefix() string
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+	// SetFlags(flag int)
+	// SetPrefix(prefix string)
+}
+
+var Logger StdLogger
+
+func init() {
+	// default Logger
+	SetLogger(stdlog.New(os.Stdout, "[restful] ", stdlog.LstdFlags|stdlog.Lshortfile))
+}
+
+func SetLogger(customLogger StdLogger) {
+	Logger = customLogger
+}
+
+func Fatal(v ...interface{}) {
+	Logger.Fatal(v...)
+}
+
+func Fatalf(format string, v ...interface{}) {
+	Logger.Fatalf(format, v...)
+}
+
+func Fatalln(v ...interface{}) {
+	Logger.Fatalln(v...)
+}
+
+func Print(v ...interface{}) {
+	Logger.Print(v...)
+}
+
+func Printf(format string, v ...interface{}) {
+	Logger.Printf(format, v...)
+}
+
+func Println(v ...interface{}) {
+	Logger.Println(v...)
+}

--- a/logger.go
+++ b/logger.go
@@ -3,30 +3,30 @@ package restful
 // Copyright 2014 Ernest Micklei. All rights reserved.
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
+import (
+	"github.com/emicklei/go-restful/log"
+)
 
 var trace bool = false
-var traceLogger Logger
+var traceLogger log.StdLogger
 
-// Logger corresponds to a subset of the interface satisfied by stdlib log.Logger
-type Logger interface {
-	Fatal(v ...interface{})
-	Fatalf(format string, v ...interface{})
-	Fatalln(v ...interface{})
-	// Flags() int
-	// Output(calldepth int, s string) error
-	// Panic(v ...interface{})
-	// Panicf(format string, v ...interface{})
-	// Panicln(v ...interface{})
-	// Prefix() string
-	Print(v ...interface{})
-	Printf(format string, v ...interface{})
-	Println(v ...interface{})
-	// SetFlags(flag int)
-	// SetPrefix(prefix string)
+func init() {
+	traceLogger = log.Logger // use the package logger by default
 }
 
 // TraceLogger enables detailed logging of Http request matching and filter invocation. Default no logger is set.
-func TraceLogger(logger Logger) {
+// You may call EnableTracing() directly to enable trace logging to the package-wide logger.
+func TraceLogger(logger log.StdLogger) {
 	traceLogger = logger
-	trace = logger != nil
+	EnableTracing(logger != nil)
+}
+
+// expose the setter for the global logger on the top-level package
+func SetLogger(customLogger log.StdLogger) {
+	log.SetLogger(customLogger)
+}
+
+// EnableTracing can be used to Trace logging on and off.
+func EnableTracing(enabled bool) {
+	trace = enabled
 }

--- a/route_builder.go
+++ b/route_builder.go
@@ -5,10 +5,11 @@ package restful
 // that can be found in the LICENSE file.
 
 import (
-	"log"
 	"reflect"
 	"runtime"
 	"strings"
+
+	"github.com/emicklei/go-restful/log"
 )
 
 // RouteBuilder is a helper to construct Routes.

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/emicklei/go-restful"
 	// "github.com/emicklei/hopwatch"
-	"log"
 	"net/http"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/emicklei/go-restful/log"
 )
 
 type SwaggerService struct {
@@ -24,7 +25,10 @@ func newSwaggerService(config Config) *SwaggerService {
 }
 
 // LogInfo is the function that is called when this package needs to log. It defaults to log.Printf
-var LogInfo = log.Printf
+var LogInfo = func(format string, v ...interface{}) {
+	// use the restful package-wide logger
+	log.Printf(format, v...)
+}
 
 // InstallSwaggerService add the WebService that provides the API documentation of all services
 // conform the Swagger documentation specifcation. (https://github.com/wordnik/swagger-core/wiki).

--- a/web_service.go
+++ b/web_service.go
@@ -1,10 +1,12 @@
 package restful
 
+import (
+	"github.com/emicklei/go-restful/log"
+)
+
 // Copyright 2013 Ernest Micklei. All rights reserved.
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
-
-import "log"
 
 // WebService holds a collection of Route values that bind a Http Method + URL Path to a function.
 type WebService struct {


### PR DESCRIPTION
closes #189 

The TraceLogger is still there and seperate because I tried not to break anything, but perhaps 
it would have been better to simply enable/disable it instead and use the same package-wide logger.
