### PR TITLE
Reduce StdLogger interface to bare minimum

### DIFF
--- a/container.go
+++ b/container.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 
@@ -108,7 +109,8 @@ func (c *Container) Add(service *WebService) *Container {
 	// cannot have duplicate root paths
 	for _, each := range c.webServices {
 		if each.RootPath() == service.RootPath() {
-			log.Fatalf("[restful] WebService with duplicate root path detected:['%v']", each)
+			log.Printf("[restful] WebService with duplicate root path detected:['%v']", each)
+			os.Exit(1)
 		}
 	}
 	// if rootPath was not set then lazy initialize it
@@ -133,7 +135,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 		}
 		buffer.WriteString(fmt.Sprintf("    %s:%d\r\n", file, line))
 	}
-	log.Println(buffer.String())
+	log.Print(buffer.String())
 	httpWriter.WriteHeader(http.StatusInternalServerError)
 	httpWriter.Write(buffer.Bytes())
 }
@@ -172,7 +174,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 			var err error
 			writer, err = NewCompressingResponseWriter(httpWriter, encoding)
 			if err != nil {
-				log.Println("[restful] unable to install compressor:", err)
+				log.Print("[restful] unable to install compressor: ", err)
 				httpWriter.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/cors_filter.go
+++ b/cors_filter.go
@@ -32,7 +32,7 @@ func (c CrossOriginResourceSharing) Filter(req *Request, resp *Response, chain *
 	origin := req.Request.Header.Get(HEADER_Origin)
 	if len(origin) == 0 {
 		if trace {
-			traceLogger.Println("no Http header Origin set")
+			traceLogger.Print("no Http header Origin set")
 		}
 		chain.ProcessFilter(req, resp)
 		return

--- a/log/log.go
+++ b/log/log.go
@@ -5,22 +5,10 @@ import (
 	"os"
 )
 
-// Logger corresponds to a subset of the interface satisfied by stdlib log.Logger
+// Logger corresponds to a minimal subset of the interface satisfied by stdlib log.Logger
 type StdLogger interface {
-	Fatal(v ...interface{})
-	Fatalf(format string, v ...interface{})
-	Fatalln(v ...interface{})
-	// Flags() int
-	// Output(calldepth int, s string) error
-	// Panic(v ...interface{})
-	// Panicf(format string, v ...interface{})
-	// Panicln(v ...interface{})
-	// Prefix() string
 	Print(v ...interface{})
 	Printf(format string, v ...interface{})
-	Println(v ...interface{})
-	// SetFlags(flag int)
-	// SetPrefix(prefix string)
 }
 
 var Logger StdLogger
@@ -34,26 +22,10 @@ func SetLogger(customLogger StdLogger) {
 	Logger = customLogger
 }
 
-func Fatal(v ...interface{}) {
-	Logger.Fatal(v...)
-}
-
-func Fatalf(format string, v ...interface{}) {
-	Logger.Fatalf(format, v...)
-}
-
-func Fatalln(v ...interface{}) {
-	Logger.Fatalln(v...)
-}
-
 func Print(v ...interface{}) {
 	Logger.Print(v...)
 }
 
 func Printf(format string, v ...interface{}) {
 	Logger.Printf(format, v...)
-}
-
-func Println(v ...interface{}) {
-	Logger.Println(v...)
 }

--- a/route_builder.go
+++ b/route_builder.go
@@ -5,6 +5,7 @@ package restful
 // that can be found in the LICENSE file.
 
 import (
+	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -136,7 +137,7 @@ func (b *RouteBuilder) Operation(name string) *RouteBuilder {
 
 // ReturnsError is deprecated, use Returns instead.
 func (b *RouteBuilder) ReturnsError(code int, message string, model interface{}) *RouteBuilder {
-	log.Println("ReturnsError is deprecated, use Returns instead.")
+	log.Print("ReturnsError is deprecated, use Returns instead.")
 	return b.Returns(code, message, model)
 }
 
@@ -189,10 +190,12 @@ func (b *RouteBuilder) copyDefaults(rootProduces, rootConsumes []string) {
 func (b *RouteBuilder) Build() Route {
 	pathExpr, err := newPathExpression(b.currentPath)
 	if err != nil {
-		log.Fatalf("[restful] Invalid path:%s because:%v", b.currentPath, err)
+		log.Printf("[restful] Invalid path:%s because:%v", b.currentPath, err)
+		os.Exit(1)
 	}
 	if b.function == nil {
-		log.Fatalf("[restful] No function specified for route:" + b.currentPath)
+		log.Printf("[restful] No function specified for route:" + b.currentPath)
+		os.Exit(1)
 	}
 	operationName := b.operation
 	if len(operationName) == 0 && b.function != nil {

--- a/web_service.go
+++ b/web_service.go
@@ -1,6 +1,8 @@
 package restful
 
 import (
+	"os"
+
 	"github.com/emicklei/go-restful/log"
 )
 
@@ -28,7 +30,8 @@ func (w *WebService) compilePathExpression() {
 	}
 	compiled, err := newPathExpression(w.rootPath)
 	if err != nil {
-		log.Fatalf("[restful] invalid path:%s because:%v", w.rootPath, err)
+		log.Printf("[restful] invalid path:%s because:%v", w.rootPath, err)
+		os.Exit(1)
 	}
 	w.pathExpr = compiled
 }


### PR DESCRIPTION
After trying yet another logging package (each has its warts) I think it would have been
better If I had opted for the most minimal Interface possible in #188, to support other loggers most easily. In addition, most of the called are rather superfluous

- The `log.Fatal*` variant is just a `Print*` + `os.Exit`, just as Panic* is a  `Print*` + Panic`. Easy to manually insert this where need in the package (as I've done here).

- The `log.Println` variant is semi-useless. `godoc fmt` says:
```
variant Println inserts blanks between operands and appends a newline.
```   

Well, The newline is irrelevent because that's handled by the log package and not by the caller. The blanks are easily inserted explicitly when there are multiple arguments. To illustrate:
```go
	log.Print("foo", "bar")
	log.Println("foo", "bar")
	log.Print("foo ", "bar")
	log.Println("foo", "bar")
```
```
2015/03/23 05:50:46 foobar
2015/03/23 05:50:46 foo bar
2015/03/23 05:50:46 foo bar
2015/03/23 05:50:46 foo bar
```

That just leaves `Print` and `Printf`, which are as little to implement as one reasonably hope.