### PR TITLE
Fix to match any mime types when Route produce "*/*"

### DIFF
--- a/route.go
+++ b/route.go
@@ -79,8 +79,8 @@ func (r Route) matchesAccept(mimeTypesWithQuality string) bool {
 		if withoutQuality == "*/*" {
 			return true
 		}
-		for _, other := range r.Produces {
-			if other == withoutQuality {
+		for _, producibleType := range r.Produces {
+			if producibleType == "*/*" || producibleType == withoutQuality {
 				return true
 			}
 		}

--- a/route_test.go
+++ b/route_test.go
@@ -31,6 +31,17 @@ func TestMatchesAcceptXml(t *testing.T) {
 	}
 }
 
+// accept should match produces
+func TestMatchesAcceptAny(t *testing.T) {
+	r := Route{Produces: []string{"*/*"}}
+	if !r.matchesAccept("application/json") {
+		t.Errorf("accept should match json")
+	}
+	if !r.matchesAccept("application/xml") {
+		t.Errorf("accept should match xml")
+	}
+}
+
 // content type should match consumes
 func TestMatchesContentTypeXml(t *testing.T) {
 	r := Route{Consumes: []string{"application/xml"}}


### PR DESCRIPTION
This PR fix to match any mime types when Route produce "\*/\*" (such as proxy).

```go
	proxyRoute := ws.Method(method).Path(path).To(routeFunction(proxyHandler)).
		Filter(monitorFilter("PROXY", resource)).
		Doc("proxy " + method + " requests to " + kind).
		Operation("proxy" + method + kind).
		Produces("*/*").
		Consumes("*/*")
	addParams(proxyRoute, params)
	ws.Route(proxyRoute)
```
https://github.com/GoogleCloudPlatform/kubernetes/blob/cfb6f1199bae1c0c7968c7322dd1f0037624236c/pkg/apiserver/api_installer.go#L638

```
% curl -H "Accept: application/json" https://example.com/...
// 406: Not Acceptable
```