### PR TITLE
Embedded structs can have a JSON tag for nesting

### DIFF
--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -647,6 +647,61 @@ func TestStructA3(t *testing.T) {
  }`)
 }
 
+type A4 struct {
+	D "json:,inline"
+}
+
+// clear && go test -v -test.run TestStructA4 ...swagger
+func TestEmbeddedStructA4(t *testing.T) {
+	testJsonFromStruct(t, A4{}, `{
+  "swagger.A4": {
+   "id": "swagger.A4",
+   "required": [
+    "Id"
+   ],
+   "properties": {
+    "Id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  }
+ }`)
+}
+
+type A5 struct {
+	D `json:"d"`
+}
+
+// clear && go test -v -test.run TestStructA5 ...swagger
+func TestEmbeddedStructA5(t *testing.T) {
+	testJsonFromStruct(t, A5{}, `{
+  "swagger.A5": {
+   "id": "swagger.A5",
+   "required": [
+    "d"
+   ],
+   "properties": {
+    "d": {
+     "$ref": "swagger.D"
+    }
+   }
+  },
+  "swagger.D": {
+   "id": "swagger.D",
+   "required": [
+    "Id"
+   ],
+   "properties": {
+    "Id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  }
+ }`)
+}
+
 type ObjectId []byte
 
 type Region struct {


### PR DESCRIPTION
A nested embedded struct (embedded in Golang, nested in JSON) is possible by
default. The inline tag forces a struct to be included by default. This
commit adds that check.

@bgrant0607 FYI we need this for v1beta3 metadata