### PR TITLE
Add all sub ref models for inline field

### DIFF
--- a/swagger/model_builder.go
+++ b/swagger/model_builder.go
@@ -197,9 +197,11 @@ func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonNam
 			if required {
 				model.Required = append(model.Required, k)
 			}
-			// Add the model type to the global model list
-			if v.Ref != nil {
-				b.Models[*v.Ref] = sub.Models[*v.Ref]
+		}
+		// add all referenced model
+		for key, sub := range sub.Models {
+			if key != subKey {
+				b.Models[key] = sub
 			}
 		}
 		// empty name signals skip property

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -702,6 +702,52 @@ func TestEmbeddedStructA5(t *testing.T) {
  }`)
 }
 
+type D2 struct {
+  id int
+  D []D
+}
+
+type A6 struct {
+  D2 "json:,inline"
+}
+
+// clear && go test -v -test.run TestStructA4 ...swagger
+func TestEmbeddedStructA6(t *testing.T) {
+  testJsonFromStruct(t, A6{}, `{
+  "swagger.A6": {
+   "id": "swagger.A6",
+   "required": [
+    "id",
+    "D"
+   ],
+   "properties": {
+    "D": {
+     "type": "array",
+     "items": {
+      "$ref": "swagger.D"
+     }
+    },
+    "id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  },
+  "swagger.D": {
+   "id": "swagger.D",
+   "required": [
+    "Id"
+   ],
+   "properties": {
+    "Id": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  }
+ }`)
+}
+
 type ObjectId []byte
 
 type Region struct {


### PR DESCRIPTION
If embeded(inlined) model has complex fields (like array of struct) then model builder should add all sub references.