### PR TITLE
Models can generate documentation through a struct method

### DIFF
--- a/swagger/README.md
+++ b/swagger/README.md
@@ -21,9 +21,56 @@ Now, you can install the Swagger WebService for serving the Swagger specificatio
 	swagger.InstallSwaggerService(config)		
 	
 	
+Documenting Structs
+--
+
+Currently there are 2 ways to document your structs in the go-restful Swagger.
+
+###### By using struct tags
+- Use tag "description" to annotate a struct field with a description to show in the UI
+- Use tag "modelDescription" to annotate the struct itself with a description to show in the UI. The tag can be added in an field of the struct and in case that there are multiple definition, they will be appended with an empty line.
+
+###### By using the SwaggerDoc method
+Here is an example with an `Address` struct and the documentation for each of the fields. The `""` is a special entry for **documenting the struct itself**.
+
+	type Address struct {
+		Country  string `json:"country,omitempty"`
+		PostCode int    `json:"postcode,omitempty"`
+	}
+
+	func (Address) SwaggerDoc() map[string]string {
+		return map[string]string{
+			"":         "Address doc",
+			"country":  "Country doc",
+			"postcode": "PostCode doc",
+		}
+	}
+
+This example will generate a JSON like this
+
+	{
+		"Address": {
+			"id": "Address",
+			"description": "Address doc",
+			"properties": {
+				"country": {
+				"type": "string",
+				"description": "Country doc"
+				},
+				"postcode": {
+				"type": "integer",
+				"format": "int32",
+				"description": "PostCode doc"
+				}
+			}
+		}
+	}
+
+**Very Important Notes:**
+- `SwaggerDoc()` is using a **NON-Pointer** receiver (e.g. func (Address) and not func (*Address))
+- The returned map should use as key the name of the field as defined in the JSON parameter (e.g. `"postcode"` and not `"PostCode"`)
+
 Notes
 --
 - The Nickname of an Operation is automatically set by finding the name of the function. You can override it using RouteBuilder.Operation(..) 
 - The WebServices field of swagger.Config can be used to control which service you want to expose and document ; you can have multiple configs and therefore multiple endpoints.
-- Use tag "description" to annotate a struct field with a description to show in the UI
-- Use tag "modelDescription" to annotate the struct itself with a description to show in the UI. The tag can be added in an field of the struct and in case that there are multiple definition, they will be appended with an empty line.

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -978,3 +978,37 @@ func TestEmbeddedStructPull204(t *testing.T) {
  }
 `)
 }
+
+type AddressWithMethod struct {
+	Country  string `json:"country,omitempty"`
+	PostCode int    `json:"postcode,omitempty"`
+}
+
+func (AddressWithMethod) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"":         "Address doc",
+		"country":  "Country doc",
+		"postcode": "PostCode doc",
+	}
+}
+
+func TestDocInMethodSwaggerDoc(t *testing.T) {
+	expected := `{
+		  "swagger.AddressWithMethod": {
+		   "id": "swagger.AddressWithMethod",
+		   "description": "Address doc",
+		   "properties": {
+		    "country": {
+		     "type": "string",
+		     "description": "Country doc"
+		    },
+		    "postcode": {
+		     "type": "integer",
+		     "format": "int32",
+		     "description": "PostCode doc"
+		    }
+		   }
+		  }
+		 }`
+	testJsonFromStruct(t, AddressWithMethod{}, expected)
+}


### PR DESCRIPTION
In [GoogleCloudPlatform/kubernetes](https://github.com/GoogleCloudPlatform/kubernetes) we are using Swagger to describe all of our types.

The problem that we are facing with the current way of describing our models is that we have to keep field and struct documentation in two different places (1) as comments 2) as struct tags so go-restful can parse). You can see [here](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/v1/types.go#L82) an example.

We think that it is easier for us to attach a method on each struct so go-restful can get the description from those methods instead of struct tags. We have a way to automatically parse the documentation from the source code and then create methods for each of our structs to contain the comments.