### PR TITLE
Paniced responses not sent with Container.EnableContentEncoding(true)

### DIFF
--- a/web_service_test.go
+++ b/web_service_test.go
@@ -50,6 +50,20 @@ func TestCapturePanic(t *testing.T) {
 	}
 }
 
+func TestCapturePanicWithEncoded(t *testing.T) {
+	tearDown()
+	Add(newPanicingService())
+	DefaultContainer.EnableContentEncoding(true)
+	httpRequest, _ := http.NewRequest("GET", "http://here.com/fire", nil)
+	httpRequest.Header.Set("Accept", "*/*")
+	httpRequest.Header.Set("Accept-Encoding", "gzip")
+	httpWriter := httptest.NewRecorder()
+	DefaultContainer.dispatch(httpWriter, httpRequest)
+	if 500 != httpWriter.Code {
+		t.Error("500 expected on fire, got", httpWriter.Code)
+	}
+}
+
 func TestNotFound(t *testing.T) {
 	tearDown()
 	httpRequest, _ := http.NewRequest("GET", "http://here.com/missing", nil)


### PR DESCRIPTION
Since the `CompressingResponseWriter` is closed before calling panic handler, every response that panic handler make will not be sent to client. This PR fixes the situation.

Also I've added a test for this situation. The test will fail with previous code.

Thank you!