### PR TITLE
fix description parsing on recursion

### DIFF
--- a/swagger/model_builder.go
+++ b/swagger/model_builder.go
@@ -20,6 +20,15 @@ type documentable interface {
 	SwaggerDoc() map[string]string
 }
 
+// Check if this structure has a method with signature func (<theModel>) SwaggerDoc() map[string]string
+// If it exists, retrive the documentation and overwrite all struct tag descriptions
+func getDocFromMethodSwaggerDoc2(model reflect.Type) map[string]string {
+	if docable, ok := reflect.New(model).Elem().Interface().(documentable); ok {
+		return docable.SwaggerDoc()
+	}
+	return make(map[string]string)
+}
+
 // addModelFrom creates and adds a Model to the builder and detects and calls
 // the post build hook for customizations
 func (b modelBuilder) addModelFrom(sample interface{}) {
@@ -27,22 +36,6 @@ func (b modelBuilder) addModelFrom(sample interface{}) {
 		// allow customizations
 		if buildable, ok := sample.(ModelBuildable); ok {
 			modelOrNil = buildable.PostBuildModel(modelOrNil)
-			b.Models.Put(modelOrNil.Id, *modelOrNil)
-		}
-		// Check if SwaggerDoc method exists and overwrite documentation
-		if docble, ok := sample.(documentable); ok {
-			fullDoc := docble.SwaggerDoc()
-
-			if modelDoc, ok := fullDoc[""]; ok {
-				modelOrNil.Description = modelDoc
-			}
-
-			for i := range modelOrNil.Properties.List {
-				prop := &modelOrNil.Properties.List[i]
-				if propDoc, ok := fullDoc[prop.Name]; ok {
-					prop.Property.Description = propDoc
-				}
-			}
 			b.Models.Put(modelOrNil.Id, *modelOrNil)
 		}
 	}
@@ -79,7 +72,9 @@ func (b modelBuilder) addModel(st reflect.Type, nameOverride string) *Model {
 		return &sm
 	}
 
+	fullDoc := getDocFromMethodSwaggerDoc2(st)
 	modelDescriptions := []string{}
+
 	for i := 0; i < st.NumField(); i++ {
 		field := st.Field(i)
 		jsonName, modelDescription, prop := b.buildProperty(field, &sm, modelName)
@@ -89,6 +84,10 @@ func (b modelBuilder) addModel(st reflect.Type, nameOverride string) *Model {
 
 		// add if not omitted
 		if len(jsonName) != 0 {
+			// update description
+			if fieldDoc, ok := fullDoc[jsonName]; ok {
+				prop.Description = fieldDoc
+			}
 			// update Required
 			if b.isPropertyRequired(field) {
 				sm.Required = append(sm.Required, jsonName)
@@ -97,7 +96,11 @@ func (b modelBuilder) addModel(st reflect.Type, nameOverride string) *Model {
 		}
 	}
 
-	if len(modelDescriptions) != 0 {
+	// We always overwrite documentation if SwaggerDoc method exists
+	// "" is special for documenting the struct itself
+	if modelDoc, ok := fullDoc[""]; ok {
+		sm.Description = modelDoc
+	} else if len(modelDescriptions) != 0 {
 		sm.Description = strings.Join(modelDescriptions, "\n")
 	}
 

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -1036,3 +1036,76 @@ func TestPtrDescription(t *testing.T) {
   }`
 	testJsonFromStruct(t, b, expected)
 }
+
+type A struct {
+	B  `json:",inline"`
+	C1 `json:"metadata,omitempty"`
+}
+
+type B struct {
+	SB string
+}
+
+type C1 struct {
+	SC string
+}
+
+func (A) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"":         "A struct",
+		"B":        "B field", // We should not get anything from this
+		"metadata": "C1 field",
+	}
+}
+
+func (B) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"":   "B struct",
+		"SB": "SB field",
+	}
+}
+
+func (C1) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"":   "C1 struct",
+		"SC": "SC field",
+	}
+}
+
+func TestNestedStructDescription(t *testing.T) {
+	expected := `
+{
+  "swagger.A": {
+   "id": "swagger.A",
+   "description": "A struct",
+   "required": [
+    "SB"
+   ],
+   "properties": {
+    "SB": {
+     "type": "string",
+     "description": "SB field"
+    },
+    "metadata": {
+     "$ref": "swagger.C1",
+     "description": "C1 field"
+    }
+   }
+  },
+  "swagger.C1": {
+   "id": "swagger.C1",
+   "description": "C1 struct",
+   "required": [
+    "SC"
+   ],
+   "properties": {
+    "SC": {
+     "type": "string",
+     "description": "SC field"
+    }
+   }
+  }
+ }
+`
+	testJsonFromStruct(t, A{}, expected)
+}


### PR DESCRIPTION
Hello, my previous commit 712d410a5f8fec68f2bce34d006a6c20c4538d88 on using descriptions from methods is not working properly.

Last time we discussed on #215 moving description parsing after `PostBuildModel`. That was a good idea but it is not enough. When we have to deal with nested models using `PostBuildModel` is making things much more complicated and also there are cases that swagger is defining models without calling `PostBuildModel` afterwords [here](https://github.com/emicklei/go-restful/blob/master/swagger/swagger_webservice.go#L258).