### PR TITLE
Update restful-CORS-filter.go

### DIFF
--- a/examples/restful-CORS-filter.go
+++ b/examples/restful-CORS-filter.go
@@ -53,7 +53,7 @@ func main() {
 	// Add container filter to enable CORS
 	cors := restful.CrossOriginResourceSharing{
 		ExposeHeaders:  []string{"X-My-Header"},
-		AllowedHeaders: []string{"Content-Type"},
+		AllowedHeaders: []string{"Content-Type", "Accept"},
 		CookiesAllowed: false,
 		Container:      wsContainer}
 	wsContainer.Filter(cors.Filter)


### PR DESCRIPTION
I needed this in order to have ajax calls work in chrome browser, without it you would get this error in trace logs:
 cors_filter.go:98: Http header Access-Control-Request-Headers:accept, content-type is not in [Content-Type]