### PR TITLE
fix bug with arrays in Writes() not parsed by swagger #228

### DIFF
--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -134,7 +134,7 @@ type Api struct {
 
 // 5.2.3 Operation Object
 type Operation struct {
-	Type             string            `json:"type"`
+	DataTypeFields
 	Method           string            `json:"method"`
 	Summary          string            `json:"summary,omitempty"`
 	Notes            string            `json:"notes,omitempty"`

--- a/swagger/swagger_test.go
+++ b/swagger/swagger_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/swagger/test_package"
 )
 
 func TestInfoStruct_Issue231(t *testing.T) {
@@ -19,7 +20,7 @@ func TestInfoStruct_Issue231(t *testing.T) {
 		},
 	}
 	sws := newSwaggerService(config)
-	str, err := json.Marshal(sws.produceListing())
+	str, err := json.MarshalIndent(sws.produceListing(), "", "    ")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,6 +57,104 @@ func TestThatMultiplePathsOnRootAreHandled(t *testing.T) {
 	if got, want := len(decl.Apis), 2; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
+}
+
+func TestWriteSamples(t *testing.T) {
+	ws1 := new(restful.WebService)
+	ws1.Route(ws1.GET("/object").To(dummy).Writes(test_package.TestStruct{}))
+	ws1.Route(ws1.GET("/array").To(dummy).Writes([]test_package.TestStruct{}))
+	ws1.Route(ws1.GET("/object_and_array").To(dummy).Writes(struct{ Abc test_package.TestStruct }{}))
+
+	cfg := Config{
+		WebServicesUrl: "http://here.com",
+		ApiPath:        "/apipath",
+		WebServices:    []*restful.WebService{ws1},
+	}
+	sws := newSwaggerService(cfg)
+
+	decl := sws.composeDeclaration(ws1, "/")
+
+	str, err := json.MarshalIndent(decl.Apis, "", "    ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareJson(t, string(str), `
+	[
+		{
+			"path": "/object",
+			"description": "",
+			"operations": [
+				{
+					"type": "test_package.TestStruct",
+					"method": "GET",
+					"nickname": "dummy",
+					"parameters": []
+				}
+			]
+		},
+		{
+			"path": "/array",
+			"description": "",
+			"operations": [
+				{
+					"type": "array",
+					"items": {
+						"$ref": "test_package.TestStruct"
+					},
+					"method": "GET",
+					"nickname": "dummy",
+					"parameters": []
+				}
+			]
+		},
+		{
+			"path": "/object_and_array",
+			"description": "",
+			"operations": [
+				{
+					"type": "struct { Abc test_package.TestStruct }",
+					"method": "GET",
+					"nickname": "dummy",
+					"parameters": []
+				}
+			]
+		}
+    ]`)
+
+	str, err = json.MarshalIndent(decl.Models, "", "    ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	compareJson(t, string(str), `
+	{
+		"test_package.TestStruct": {
+			"id": "test_package.TestStruct",
+			"required": [
+				"TestField"
+			],
+			"properties": {
+				"TestField": {
+					"type": "string"
+				}
+			}
+		},
+		"||test_package.TestStruct": {
+			"id": "||test_package.TestStruct",
+			"properties": {}
+		},
+		"struct { Abc test_package.TestStruct }": {
+			"id": "struct { Abc test_package.TestStruct }",
+			"required": [
+				"Abc"
+			],
+			"properties": {
+				"Abc": {
+					"$ref": "test_package.TestStruct"
+				}
+			}
+		}
+    }`)
 }
 
 // go test -v -test.run TestServiceToApi ...swagger
@@ -99,6 +198,7 @@ func TestServiceToApi(t *testing.T) {
 			pathOrder += other.Method
 		}
 	}
+
 	if pathOrder != "/tests/aGETDELETE/tests/bPUTPOST/tests/cPOSTPUT/tests/dDELETEGET" {
 		t.Errorf("got %v want %v", pathOrder, "see test source")
 	}

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -213,12 +213,14 @@ func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix 
 	}
 	pathToRoutes.Do(func(path string, routes []restful.Route) {
 		api := Api{Path: strings.TrimSuffix(path, "/"), Description: ws.Documentation()}
+		voidString := "void"
 		for _, route := range routes {
-			// this gets overwritten if there is a write sample
 			operation := Operation{
-				Method:           route.Method,
-				Summary:          route.Doc,
-				Notes:            route.Notes,
+				Method:  route.Method,
+				Summary: route.Doc,
+				Notes:   route.Notes,
+				// Type gets overwritten if there is a write sample
+				DataTypeFields:   DataTypeFields{Type: &voidString},
 				Parameters:       []Parameter{},
 				Nickname:         route.Operation,
 				ResponseMessages: composeResponseMessages(route, &decl)}
@@ -283,9 +285,6 @@ func (sws SwaggerService) addModelsFromRouteTo(operation *Operation, route restf
 	}
 	if route.WriteSample != nil {
 		sws.addModelFromSampleTo(operation, true, route.WriteSample, &decl.Models)
-	} else {
-		tmp := "void"
-		operation.Type = &tmp
 	}
 }
 

--- a/swagger/test_package/struct.go
+++ b/swagger/test_package/struct.go
@@ -1,0 +1,5 @@
+package test_package
+
+type TestStruct struct {
+	TestField string
+}

--- a/swagger/utils_test.go
+++ b/swagger/utils_test.go
@@ -23,14 +23,24 @@ func modelsFromStruct(sample interface{}) *ModelList {
 }
 
 func compareJson(t *testing.T, actualJsonAsString string, expectedJsonAsString string) bool {
+	success := false
 	var actualMap map[string]interface{}
 	json.Unmarshal([]byte(actualJsonAsString), &actualMap)
 	var expectedMap map[string]interface{}
 	err := json.Unmarshal([]byte(expectedJsonAsString), &expectedMap)
 	if err != nil {
-		t.Fatalf("Unparsable expected JSON: %s", err)
+		var actualArray []interface{}
+		json.Unmarshal([]byte(actualJsonAsString), &actualArray)
+		var expectedArray []interface{}
+		err := json.Unmarshal([]byte(expectedJsonAsString), &expectedArray)
+		success = reflect.DeepEqual(actualArray, expectedArray)
+		if err != nil {
+			t.Fatalf("Unparsable expected JSON: %s", err)
+		}
+	} else {
+		success = reflect.DeepEqual(actualMap, expectedMap)
 	}
-	if !reflect.DeepEqual(actualMap, expectedMap) {
+	if !success {
 		t.Log("---- expected -----")
 		t.Log(withLineNumbers(expectedJsonAsString))
 		t.Log("---- actual -----")


### PR DESCRIPTION
This allows you to specify an array in Writes(). (related to #228)

It looks like the spec doesn't support arrays in "responses" because they have to use a "responseModel" which is a string reference to a model. A model can't be an array AFAIK.

This is a good compromise because in most cases Writes() is sufficient for expressing the return type of an API.

I might not have written this patch in the best way possible, so feel free to completely rewrite it. I also didn't see an easy way to test the output, but at least I made sure that the code gets executed in a test case.