### PR TITLE
Adds format to Parameter in go-restful for use in Swagger UI

### DIFF
--- a/parameter.go
+++ b/parameter.go
@@ -30,12 +30,12 @@ type Parameter struct {
 // ParameterData represents the state of a Parameter.
 // It is made public to make it accessible to e.g. the Swagger package.
 type ParameterData struct {
-	Name, Description, DataType string
-	Kind                        int
-	Required                    bool
-	AllowableValues             map[string]string
-	AllowMultiple               bool
-	DefaultValue                string
+	Name, Description, DataType, DataFormat string
+	Kind                                    int
+	Required                                bool
+	AllowableValues                         map[string]string
+	AllowMultiple                           bool
+	DefaultValue                            string
 }
 
 // Data returns the state of the Parameter
@@ -92,6 +92,12 @@ func (p *Parameter) AllowableValues(values map[string]string) *Parameter {
 // DataType sets the dataType field and returns the receiver
 func (p *Parameter) DataType(typeName string) *Parameter {
 	p.data.DataType = typeName
+	return p
+}
+
+// DataFormat sets the dataFormat field for Swagger UI
+func (p *Parameter) DataFormat(formatName string) *Parameter {
+	p.data.DataFormat = formatName
 	return p
 }
 

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -320,7 +320,7 @@ func asSwaggerParameter(param restful.ParameterData) Parameter {
 	return Parameter{
 		DataTypeFields: DataTypeFields{
 			Type:         &param.DataType,
-			Format:       asFormat(param.DataType),
+			Format:       asFormat(param.DataType, param.DataFormat),
 			DefaultValue: Special(param.DefaultValue),
 		},
 		Name:        param.Name,
@@ -365,7 +365,10 @@ func composeRootPath(req *restful.Request) string {
 	return path + "/" + g
 }
 
-func asFormat(name string) string {
+func asFormat(dataType string, dataFormat string) string {
+	if dataFormat != "" {
+		return dataFormat
+	}
 	return "" // TODO
 }
 


### PR DESCRIPTION
Adds format to Parameter in go-restful and use it for the Format in Swagger UI.

This will fix issues such as the need to have dataType: "string" and dataFormat: "date-time"
https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#431-primitives

I made it "backwards compatible" as I'm not sure what the original plan was for the //TODO in asFormat()

Change-Id: I29bed78705e42a4c09c0bb85c08f0d232b1b40d0