### PR TITLE
Removed left fmt.Println method in SwaggerService

### DIFF
--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -200,7 +200,6 @@ func (sws SwaggerService) produceAllDeclarations() map[string]ApiDeclaration {
 }
 
 func (sws SwaggerService) produceDeclarations(route string) (*ApiDeclaration, bool) {
-	fmt.Println(sws.apiDeclarationMap)
 	decl, ok := sws.apiDeclarationMap.At(route)
 	if !ok {
 		return nil, false


### PR DESCRIPTION
Hi,

there was a smuggled fmt.Println method call in one of previous pull-requests, probably used for debugging. I removed this call.