### PR TITLE
Proposed addition of 'type' tag for swagger

### DIFF
--- a/swagger/model_property_ext.go
+++ b/swagger/model_property_ext.go
@@ -31,6 +31,12 @@ func (prop *ModelProperty) setMaximum(field reflect.StructField) {
 	}
 }
 
+func (prop *ModelProperty) setType(field reflect.StructField) {
+	if tag := field.Tag.Get("type"); tag != "" {
+		prop.Type = &tag
+	}
+}
+
 func (prop *ModelProperty) setMinimum(field reflect.StructField) {
 	if tag := field.Tag.Get("minimum"); tag != "" {
 		prop.Minimum = tag
@@ -56,4 +62,5 @@ func (prop *ModelProperty) setPropertyMetadata(field reflect.StructField) {
 	prop.setMaximum(field)
 	prop.setUniqueItems(field)
 	prop.setDefaultValue(field)
+	prop.setType(field)
 }

--- a/swagger/model_property_ext_test.go
+++ b/swagger/model_property_ext_test.go
@@ -4,11 +4,13 @@ import "testing"
 
 // clear && go test -v -test.run TestThatExtraTagsAreReadIntoModel ...swagger
 func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
+	type fakeint int
 	type Anything struct {
-		Name     string `description:"name" modelDescription:"a test"`
-		Size     int    `minimum:"0" maximum:"10"`
-		Stati    string `enum:"off|on" default:"on" modelDescription:"more description"`
-		ID       string `unique:"true"`
+		Name     string  `description:"name" modelDescription:"a test"`
+		Size     int     `minimum:"0" maximum:"10"`
+		Stati    string  `enum:"off|on" default:"on" modelDescription:"more description"`
+		ID       string  `unique:"true"`
+		FakeInt  fakeint `type:"integer"`
 		Password string
 	}
 	m := modelsFromStruct(Anything{})
@@ -37,6 +39,10 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 	}
 	p5, _ := props.Properties.At("Password")
 	if got, want := *p5.Type, "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p6, _ := props.Properties.At("FakeInt")
+	if got, want := *p6.Type, "integer"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 


### PR DESCRIPTION
Currently I have some struct fields that are essentially a type alias for an integer.  They do not show up in my swagger documentation when I pass them to Reads(), they are omitted entirely.  In the long term, it might be nice for the reflection magic in the swagger model_builder etc could detect these and handle them as though they were the appropriate type.  Implementing a MarshalJSON method on my aliased type did get them to show up in the swagger documentation, but always as type "string" versus integer.  This PR is much less ambitious than a fix for the above, but could prove generically useful in the event that we ever wanted to override the type that was guessed.