### PR TITLE
Adding 'type' struct tag that can override the guessed type

### DIFF
--- a/swagger/model_builder.go
+++ b/swagger/model_builder.go
@@ -132,9 +132,11 @@ func (b modelBuilder) buildProperty(field reflect.StructField, model *Model, mod
 		modelDescription = tag
 	}
 
-	fieldType := field.Type
-
 	prop.setPropertyMetadata(field)
+	if prop.Type != nil {
+		return jsonName, modelDescription, prop
+	}
+	fieldType := field.Type
 
 	// check if type is doing its own marshalling
 	marshalerType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
@@ -212,8 +214,12 @@ func hasNamedJSONTag(field reflect.StructField) bool {
 }
 
 func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonName string, model *Model) (nameJson string, prop ModelProperty) {
-	fieldType := field.Type
 	prop.setPropertyMetadata(field)
+	// Check for type override in tag
+	if field.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
 	// check for anonymous
 	if len(fieldType.Name()) == 0 {
 		// anonymous
@@ -263,8 +269,12 @@ func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonNam
 }
 
 func (b modelBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop ModelProperty) {
-	fieldType := field.Type
+	// check for type override in tags
 	prop.setPropertyMetadata(field)
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
 	var pType = "array"
 	prop.Type = &pType
 	elemTypeName := b.getElementTypeName(modelName, jsonName, fieldType.Elem())
@@ -284,8 +294,12 @@ func (b modelBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName
 }
 
 func (b modelBuilder) buildPointerTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop ModelProperty) {
-	fieldType := field.Type
 	prop.setPropertyMetadata(field)
+	// Check for type override in tags
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
 
 	// override type of pointer to list-likes
 	if fieldType.Elem().Kind() == reflect.Slice || fieldType.Elem().Kind() == reflect.Array {

--- a/swagger/model_property_ext.go
+++ b/swagger/model_property_ext.go
@@ -31,6 +31,12 @@ func (prop *ModelProperty) setMaximum(field reflect.StructField) {
 	}
 }
 
+func (prop *ModelProperty) setType(field reflect.StructField) {
+	if tag := field.Tag.Get("type"); tag != "" {
+		prop.Type = &tag
+	}
+}
+
 func (prop *ModelProperty) setMinimum(field reflect.StructField) {
 	if tag := field.Tag.Get("minimum"); tag != "" {
 		prop.Minimum = tag
@@ -56,4 +62,5 @@ func (prop *ModelProperty) setPropertyMetadata(field reflect.StructField) {
 	prop.setMaximum(field)
 	prop.setUniqueItems(field)
 	prop.setDefaultValue(field)
+	prop.setType(field)
 }

--- a/swagger/model_property_ext_test.go
+++ b/swagger/model_property_ext_test.go
@@ -1,14 +1,20 @@
 package swagger
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 // clear && go test -v -test.run TestThatExtraTagsAreReadIntoModel ...swagger
 func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
+	type fakeint int
 	type Anything struct {
-		Name     string `description:"name" modelDescription:"a test"`
-		Size     int    `minimum:"0" maximum:"10"`
-		Stati    string `enum:"off|on" default:"on" modelDescription:"more description"`
-		ID       string `unique:"true"`
+		Name     string  `description:"name" modelDescription:"a test"`
+		Size     int     `minimum:"0" maximum:"10"`
+		Stati    string  `enum:"off|on" default:"on" modelDescription:"more description"`
+		ID       string  `unique:"true"`
+		FakeInt  fakeint `type:"integer"`
+		IP       net.IP  `type:"string"`
 		Password string
 	}
 	m := modelsFromStruct(Anything{})
@@ -37,6 +43,14 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 	}
 	p5, _ := props.Properties.At("Password")
 	if got, want := *p5.Type, "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p6, _ := props.Properties.At("FakeInt")
+	if got, want := *p6.Type, "integer"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p7, _ := props.Properties.At("IP")
+	if got, want := *p7.Type, "string"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 


### PR DESCRIPTION
This is a more complete version of my earlier PR.  This adds a "type" struct tag that can override the type guessed by reflection.  I have updated the unit tests with some examples of where this might be useful, as an example a net.IP type and an int type alias.  net.IP is itself a type alias for []byte, but it implements json.Unmarshaler and json.Marshaler to allow it to be represented as a string or converted from a string.