### PR TITLE
cors filter to use default container

### DIFF
--- a/cors_filter.go
+++ b/cors_filter.go
@@ -74,7 +74,11 @@ func (c CrossOriginResourceSharing) doActualRequest(req *Request, resp *Response
 
 func (c *CrossOriginResourceSharing) doPreflightRequest(req *Request, resp *Response) {
 	if len(c.AllowedMethods) == 0 {
-		c.AllowedMethods = c.Container.computeAllowedMethods(req)
+		if c.Container == nil {
+			c.AllowedMethods = DefaultContainer.computeAllowedMethods(req)
+		} else {
+			c.AllowedMethods = c.Container.computeAllowedMethods(req)
+		}
 	}
 
 	acrm := req.Request.Header.Get(HEADER_AccessControlRequestMethod)


### PR DESCRIPTION
I initialize services and containers like below:

```
	// Register all rest endpoints.
	ws := &restful.WebService{}
	ws.Path(fmt.Sprintf("/api/%s", api.APIVersion)).
		Consumes(restful.MIME_JSON).
		Produces(restful.MIME_JSON)
	registerAPIs(ws)
	restful.Add(ws)

	// Add container filter to enable CORS and respond to OPTIONS.
	cors := restful.CrossOriginResourceSharing{
		ExposeHeaders:  []string{"X-My-Header"},
		AllowedHeaders: []string{"Content-Type"},
		CookiesAllowed: false,
	}
	restful.Filter(cors.Filter)
	restful.Filter(restful.OPTIONSFilter())
```

When receiving request, it gives me an invalid memory access error.  Since we already assumes DefaultContainer in quite a few place, it makes sense to also assume default container here as well.  

doPreflightRequest is the only place that accesses c.Container, but we could go with a `NewCrossOriginResourceSharing()` method, which we can assign default container or give error message if container is empty.