### PR TITLE
Implement http.Hijacker interface on CompressingResponseWriter

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -9,7 +9,6 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -78,7 +77,7 @@ func (c *CompressingResponseWriter) isCompressorClosed() bool {
 func (c *CompressingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := c.writer.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("ResponseWriter doesn't support Hijacker interface")
+		return nil, nil, errors.New("ResponseWriter doesn't support Hijacker interface")
 	}
 	return hijacker.Hijack()
 }

--- a/compress.go
+++ b/compress.go
@@ -5,10 +5,13 @@ package restful
 // that can be found in the LICENSE file.
 
 import (
+	"bufio"
 	"compress/gzip"
 	"compress/zlib"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -67,6 +70,17 @@ func (c *CompressingResponseWriter) Close() error {
 
 func (c *CompressingResponseWriter) isCompressorClosed() bool {
 	return nil == c.compressor
+}
+
+// Hijack implements the Hijacker interface
+// This is especially useful when combining Container.EnabledContentEncoding
+// in combination with websockets (for instance gorilla/websocket)
+func (c *CompressingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := c.writer.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("ResponseWriter doesn't support Hijacker interface")
+	}
+	return hijacker.Hijack()
 }
 
 // WantsCompressedResponse reads the Accept-Encoding header to see if and which encoding is requested.


### PR DESCRIPTION
When using a single `Container` that included routes for websockets it was discovered that setting `EnableContentEncoding(true)` was causing an error with gorilla's `websocket.Upgrader` as the `CompressingResponseWriter` does not implement the `http.Hijacker` interface.  This change adds a simple Hijack implementation that allows for the use of websocket endpoints within a `Container` when `EnableContentEncoding(true)` is set. 