### PR TITLE
Fix invalid compared Swagger paths

### DIFF
--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -226,10 +226,9 @@ func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix 
 	pathToRoutes := newOrderedRouteMap()
 	for _, other := range ws.Routes() {
 		if strings.HasPrefix(other.Path, pathPrefix) {
-			if len(other.Path) > len(pathPrefix) && other.Path[len(pathPrefix)] != '/' {
+			if len(pathPrefix) > 1 && len(other.Path) > len(pathPrefix) && other.Path[len(pathPrefix)] != '/' {
 				continue
 			}
-
 			pathToRoutes.Add(other.Path, other)
 		}
 	}

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -226,6 +226,10 @@ func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix 
 	pathToRoutes := newOrderedRouteMap()
 	for _, other := range ws.Routes() {
 		if strings.HasPrefix(other.Path, pathPrefix) {
+			if len(other.Path) > len(pathPrefix) && other.Path[len(pathPrefix)] != '/' {
+				continue
+			}
+
 			pathToRoutes.Add(other.Path, other)
 		}
 	}

--- a/swagger/utils_test.go
+++ b/swagger/utils_test.go
@@ -35,7 +35,7 @@ func compareJson(t *testing.T, actualJsonAsString string, expectedJsonAsString s
 		err := json.Unmarshal([]byte(expectedJsonAsString), &expectedArray)
 		success = reflect.DeepEqual(actualArray, expectedArray)
 		if err != nil {
-			t.Fatalf("Unparsable expected JSON: %s", err)
+			t.Fatalf("Unparsable expected JSON: %s, actual: %v, expected: %v", err, actualJsonAsString, expectedJsonAsString)
 		}
 	} else {
 		success = reflect.DeepEqual(actualMap, expectedMap)


### PR DESCRIPTION
Hi,

I have defined two webservices:

/foobar
/foo

Each of them has defined GET and HEAD routes. When listing swagger API declarations, endpoints corresponding to /foo are also listed under /foobar.

Fix checks if there are compared entire paths instead of sudden exact substrings.

Please review the pull request.

Kind regards,
Marcin
