### PR TITLE
Fixing panic during remove route of last route in webservice

### DIFF
--- a/web_service.go
+++ b/web_service.go
@@ -159,11 +159,16 @@ func (w *WebService) RemoveRoute(path, method string) error {
 	}
 	w.routesLock.Lock()
 	defer w.routesLock.Unlock()
+	newRoutes := make([]Route, (len(w.routes) - 1))
+	current := 0
 	for ix := range w.routes {
 		if w.routes[ix].Method == method && w.routes[ix].Path == path {
-			w.routes = append(w.routes[:ix], w.routes[ix+1:]...)
+			continue
 		}
+		newRoutes[current] = w.routes[ix]
+		current = current + 1
 	}
+	w.routes = newRoutes
 	return nil
 }
 

--- a/web_service_test.go
+++ b/web_service_test.go
@@ -171,6 +171,41 @@ func TestRemoveRoute(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }
+func TestRemoveLastRoute(t *testing.T) {
+	tearDown()
+	TraceLogger(testLogger{t})
+	ws := newGetPlainTextOrJsonServiceMultiRoute()
+	Add(ws)
+	httpRequest, _ := http.NewRequest("GET", "http://here.com/get", nil)
+	httpRequest.Header.Set("Accept", "text/plain")
+	httpWriter := httptest.NewRecorder()
+	DefaultContainer.dispatch(httpWriter, httpRequest)
+	if got, want := httpWriter.Code, 200; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// dynamic apis are disabled, should error and do nothing
+	if err := ws.RemoveRoute("/get", "GET"); err == nil {
+		t.Error("unexpected non-error")
+	}
+
+	httpWriter = httptest.NewRecorder()
+	DefaultContainer.dispatch(httpWriter, httpRequest)
+	if got, want := httpWriter.Code, 200; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	ws.SetDynamicRoutes(true)
+	if err := ws.RemoveRoute("/get", "GET"); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	httpWriter = httptest.NewRecorder()
+	DefaultContainer.dispatch(httpWriter, httpRequest)
+	if got, want := httpWriter.Code, 404; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
 
 // go test -v -test.run TestContentTypeOctet_Issue170 ...restful
 func TestContentTypeOctet_Issue170(t *testing.T) {
@@ -223,6 +258,14 @@ func newGetPlainTextOrJsonService() *WebService {
 	ws := new(WebService).Path("")
 	ws.Produces("text/plain", "application/json")
 	ws.Route(ws.GET("/get").To(doNothing))
+	return ws
+}
+
+func newGetPlainTextOrJsonServiceMultiRoute() *WebService {
+	ws := new(WebService).Path("")
+	ws.Produces("text/plain", "application/json")
+	ws.Route(ws.GET("/get").To(doNothing))
+	ws.Route(ws.GET("/status").To(doNothing))
 	return ws
 }
 


### PR DESCRIPTION
Solves the issue during a call to remove the last route of the webservice

```
E0410 07:26:58.832374       1 runtime.go:58] Recovered from panic: "index out of range" (runtime error: index out of range)
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:52
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:40
/usr/local/go/src/runtime/asm_amd64.s:472
/usr/local/go/src/runtime/panic.go:426
/usr/local/go/src/runtime/panic.go:15
/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/emicklei/go-restful/web_service.go:16
```

This solves the issue of IndexOutOfBounds from https://github.com/emicklei/go-restful/blob/master/web_service.go#L164