### PR TITLE
fix compile path twice issue

### DIFF
--- a/web_service.go
+++ b/web_service.go
@@ -36,9 +36,6 @@ func (w *WebService) SetDynamicRoutes(enable bool) {
 
 // compilePathExpression ensures that the path is compiled into a RegEx for those routers that need it.
 func (w *WebService) compilePathExpression() {
-	if len(w.rootPath) == 0 {
-		w.Path("/") // lazy initialize path
-	}
 	compiled, err := newPathExpression(w.rootPath)
 	if err != nil {
 		log.Printf("[restful] invalid path:%s because:%v", w.rootPath, err)
@@ -60,6 +57,9 @@ func (w WebService) Version() string { return w.apiVersion }
 // All Routes will be relative to this path.
 func (w *WebService) Path(root string) *WebService {
 	w.rootPath = root
+	if len(w.rootPath) == 0 {
+		w.rootPath = "/"
+	}
 	w.compilePathExpression()
 	return w
 }


### PR DESCRIPTION
@emicklei ptal.
This will change `Path("") --> compilePathExpression() --> Path("/") --> compilePathExpression()` to `Path("") --> compilePathExpression()`