### PR TITLE
wrong package breaks vendoring (gb)

### DIFF
--- a/examples/restful-curly-router_test.go
+++ b/examples/restful-curly-router_test.go
@@ -1,4 +1,4 @@
-package examples
+package main
 
 import (
 	"bytes"


### PR DESCRIPTION
The package for examples/restful-curly-router_test.go file was set to examples, instead of main like the rest of the files in that directory, which was breaking gb vendoring.