### PR TITLE
Fixing typo in Operation receiver method documentation

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -128,7 +128,7 @@ func (b *RouteBuilder) Param(parameter *Parameter) *RouteBuilder {
 	return b
 }
 
-// Operation allows you to document what the acutal method/function call is of the Route.
+// Operation allows you to document what the actual method/function call is of the Route.
 // Unless called, the operation name is derived from the RouteFunction set using To(..).
 func (b *RouteBuilder) Operation(name string) *RouteBuilder {
 	b.operation = name


### PR DESCRIPTION
Just a small typo fix