### PR TITLE
Customizable typename-to-swagger-format-field map

### DIFF
--- a/swagger/config.go
+++ b/swagger/config.go
@@ -9,6 +9,8 @@ import (
 // PostBuildDeclarationMapFunc can be used to modify the api declaration map.
 type PostBuildDeclarationMapFunc func(apiDeclarationMap *ApiDeclarationList)
 
+type MapSchemaFormatFunc func(typeName string) string
+
 type Config struct {
 	// url where the services are available, e.g. http://localhost:8080
 	// if left empty then the basePath of Swagger is taken from the actual request
@@ -31,4 +33,6 @@ type Config struct {
 	PostBuildHandler PostBuildDeclarationMapFunc
 	// Swagger global info struct
 	Info Info
+	// [optional] If set, model builder should call this handler to get addition typename-to-swagger-format-field convertion.
+	SchemaFormatHandler MapSchemaFormatFunc
 }

--- a/swagger/model_builder.go
+++ b/swagger/model_builder.go
@@ -14,6 +14,7 @@ type ModelBuildable interface {
 
 type modelBuilder struct {
 	Models *ModelList
+	Config *Config
 }
 
 type documentable interface {
@@ -231,7 +232,7 @@ func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonNam
 
 	if field.Name == fieldType.Name() && field.Anonymous && !hasNamedJSONTag(field) {
 		// embedded struct
-		sub := modelBuilder{new(ModelList)}
+		sub := modelBuilder{new(ModelList), b.Config}
 		sub.addModel(fieldType, "")
 		subKey := sub.keyFrom(fieldType)
 		// merge properties from sub
@@ -410,6 +411,11 @@ func (b modelBuilder) jsonSchemaType(modelName string) string {
 }
 
 func (b modelBuilder) jsonSchemaFormat(modelName string) string {
+	if b.Config != nil && b.Config.SchemaFormatHandler != nil {
+		if mapped := b.Config.SchemaFormatHandler(modelName); mapped != "" {
+			return mapped
+		}
+	}
 	schemaMap := map[string]string{
 		"int":        "int32",
 		"int32":      "int32",

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -38,6 +38,59 @@ func TestRef_Issue190(t *testing.T) {
  }`)
 }
 
+func TestWithoutAdditionalFormat(t *testing.T) {
+	type mytime struct {
+		time.Time
+	}
+	type usemytime struct {
+		t mytime
+	}
+	testJsonFromStruct(t, usemytime{}, `{
+  "swagger.usemytime": {
+   "id": "swagger.usemytime",
+   "required": [
+    "t"
+   ],
+   "properties": {
+    "t": {
+     "type": "string"
+    }
+   }
+  }
+ }`)
+}
+
+func TestWithAdditionalFormat(t *testing.T) {
+	type mytime struct {
+		time.Time
+	}
+	type usemytime struct {
+		t mytime
+	}
+	testJsonFromStructWithConfig(t, usemytime{}, `{
+  "swagger.usemytime": {
+   "id": "swagger.usemytime",
+   "required": [
+    "t"
+   ],
+   "properties": {
+    "t": {
+     "type": "string",
+     "format": "date-time"
+    }
+   }
+  }
+ }`, &Config {
+ 	SchemaFormatHandler: func(typeName string) string {
+		switch typeName {
+		case "swagger.mytime":
+			return "date-time"
+		}
+		return ""
+ 	},
+ })
+}
+
 // clear && go test -v -test.run TestCustomMarshaller_Issue96 ...swagger
 func TestCustomMarshaller_Issue96(t *testing.T) {
 	type Vote struct {

--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -294,7 +294,7 @@ func composeResponseMessages(route restful.Route, decl *ApiDeclaration) (message
 			if isCollection {
 				modelName = "array[" + modelName + "]"
 			}
-			modelBuilder{&decl.Models}.addModel(st, "")
+			modelBuilder{Models: &decl.Models}.addModel(st, "")
 			// reference the model
 			message.ResponseModel = modelName
 		}
@@ -332,11 +332,11 @@ func detectCollectionType(st reflect.Type) (bool, reflect.Type) {
 // addModelFromSample creates and adds (or overwrites) a Model from a sample resource
 func (sws SwaggerService) addModelFromSampleTo(operation *Operation, isResponse bool, sample interface{}, models *ModelList) {
 	if isResponse {
-		type_, items := asDataType(sample)
+		type_, items := asDataType(sample, &sws.config)
 		operation.Type = type_
 		operation.Items = items
 	}
-	modelBuilder{models}.addModelFrom(sample)
+	modelBuilder{Models: models, Config: &sws.config}.addModelFrom(sample)
 }
 
 func asSwaggerParameter(param restful.ParameterData) Parameter {
@@ -411,7 +411,7 @@ func asParamType(kind int) string {
 	return ""
 }
 
-func asDataType(any interface{}) (*string, *Item) {
+func asDataType(any interface{}, config *Config) (*string, *Item) {
 	// If it's not a collection, return the suggested model name
 	st := reflect.TypeOf(any)
 	isCollection, st := detectCollectionType(st)
@@ -424,7 +424,7 @@ func asDataType(any interface{}) (*string, *Item) {
 	// XXX: This is not very elegant
 	// We create an Item object referring to the given model
 	models := ModelList{}
-	mb := modelBuilder{&models}
+	mb := modelBuilder{Models: &models, Config: config}
 	mb.addModelFrom(any)
 
 	elemTypeName := mb.getElementTypeName(modelName, "", st)

--- a/swagger/utils_test.go
+++ b/swagger/utils_test.go
@@ -9,17 +9,25 @@ import (
 	"testing"
 )
 
-func testJsonFromStruct(t *testing.T, sample interface{}, expectedJson string) bool {
-	m := modelsFromStruct(sample)
+func testJsonFromStructWithConfig(t *testing.T, sample interface{}, expectedJson string, config *Config) bool {
+	m := modelsFromStructWithConfig(sample, config)
 	data, _ := json.MarshalIndent(m, " ", " ")
 	return compareJson(t, string(data), expectedJson)
 }
 
-func modelsFromStruct(sample interface{}) *ModelList {
+func modelsFromStructWithConfig(sample interface{}, config *Config) *ModelList {
 	models := new(ModelList)
-	builder := modelBuilder{models}
+	builder := modelBuilder{Models: models, Config: config}
 	builder.addModelFrom(sample)
 	return models
+}
+
+func testJsonFromStruct(t *testing.T, sample interface{}, expectedJson string) bool {
+	return testJsonFromStructWithConfig(t, sample, expectedJson, &Config{})
+}
+
+func modelsFromStruct(sample interface{}) *ModelList {
+	return modelsFromStructWithConfig(sample, &Config{})
 }
 
 func compareJson(t *testing.T, actualJsonAsString string, expectedJsonAsString string) bool {


### PR DESCRIPTION
For a type that is marshaled manually, we do not have a way to specify its format. For example if we have a custom_time type that does not provided a custom marshaling, its swagger type would be string and its swagger format would be empty. The correct swagger format in this example is "date-time". This PR adds a function that maps type-name to swagger-format-field. If the function exists in swagger.Config and returns non-empty strings, that value will be used instead of internal model-builder map. #296 