### PR TITLE
Add "Info" to go-restful ApiDecl

### DIFF
--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -118,6 +118,7 @@ type ApiDeclaration struct {
 	ApiVersion     string          `json:"apiVersion"`
 	BasePath       string          `json:"basePath"`
 	ResourcePath   string          `json:"resourcePath"` // must start with /
+	Info           Info            `json:"info"`
 	Apis           []Api           `json:"apis,omitempty"`
 	Models         ModelList       `json:"models,omitempty"`
 	Produces       []string        `json:"produces,omitempty"`


### PR DESCRIPTION
Allows post processing of ApiDecl to set the info field for swagger 1.0
(to add things like descriptions of APIs).