### PR TITLE
Allow passing on url param to swagger ui

### DIFF
--- a/swagger/swagger_webservice.go
+++ b/swagger/swagger_webservice.go
@@ -104,6 +104,11 @@ func RegisterSwaggerService(config Config, wsContainer *restful.Container) {
 			swaggerPathSlash += "/"
 
 		}
+
+		if config.swaggerUrl != nil {
+			swaggerPathSlash += "?url=" + config.swaggerUrl
+		}
+
 		LogInfo("[restful/swagger] %v%v is mapped to custom Handler %T", config.WebServicesUrl, swaggerPathSlash, config.StaticHandler)
 		wsContainer.Handle(swaggerPathSlash, config.StaticHandler)
 


### PR DESCRIPTION
Swagger ui takes the default file it refers to as a query parameter in the
URL. This will append the given URL if it was given as a config parameter.

**NOTE**: I am new to golang and this is more like a "feature request". But it would be nice with something similar like this. Allowing you to pass the swagger JSON as the `url=` argument to swagger-ui, so that you don't get some petstore stuff by default.

Note that I have not tested this. Because I have yet to figure out how to easily replace an import to point to my fork when developing in a golang docker image with minimal effort.
