### PR TITLE
Adding slice/array functionality to 'type' struct tag.

### DIFF
--- a/swagger/model_property_ext.go
+++ b/swagger/model_property_ext.go
@@ -33,6 +33,21 @@ func (prop *ModelProperty) setMaximum(field reflect.StructField) {
 
 func (prop *ModelProperty) setType(field reflect.StructField) {
 	if tag := field.Tag.Get("type"); tag != "" {
+		// Check if the first two characters of the type tag are
+		// intended to emulate slice/array behaviour.
+		//
+		// If type is intended to be a slice/array then add the
+		// overriden type to the array item instead of the main property
+		if len(tag) > 2 && tag[0:2] == "[]" {
+			pType := "array"
+			prop.Type = &pType
+			prop.Items = new(Item)
+
+			iType := tag[2:]
+			prop.Items.Type = &iType
+			return
+		}
+
 		prop.Type = &tag
 	}
 }

--- a/swagger/model_property_ext_test.go
+++ b/swagger/model_property_ext_test.go
@@ -8,14 +8,16 @@ import (
 // clear && go test -v -test.run TestThatExtraTagsAreReadIntoModel ...swagger
 func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 	type fakeint int
+	type fakearray string
 	type Anything struct {
-		Name     string  `description:"name" modelDescription:"a test"`
-		Size     int     `minimum:"0" maximum:"10"`
-		Stati    string  `enum:"off|on" default:"on" modelDescription:"more description"`
-		ID       string  `unique:"true"`
-		FakeInt  fakeint `type:"integer"`
-		IP       net.IP  `type:"string"`
-		Password string
+		Name      string    `description:"name" modelDescription:"a test"`
+		Size      int       `minimum:"0" maximum:"10"`
+		Stati     string    `enum:"off|on" default:"on" modelDescription:"more description"`
+		ID        string    `unique:"true"`
+		FakeInt   fakeint   `type:"integer"`
+		FakeArray fakearray `type:"[]string"`
+		IP        net.IP    `type:"string"`
+		Password  string
 	}
 	m := modelsFromStruct(Anything{})
 	props, _ := m.At("swagger.Anything")
@@ -49,8 +51,16 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 	if got, want := *p6.Type, "integer"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
-	p7, _ := props.Properties.At("IP")
-	if got, want := *p7.Type, "string"; got != want {
+	p7, _ := props.Properties.At("FakeArray")
+	if got, want := *p7.Type, "array"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p7p, _ := props.Properties.At("FakeArray")
+	if got, want := *p7p.Items.Type, "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p8, _ := props.Properties.At("IP")
+	if got, want := *p8.Type, "string"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 


### PR DESCRIPTION
This pull request was born whilst using a custom type as a slice in a model struct.

The custom type `bson.ObjectId` implements correct marshaling, however when used as a slice/array in a model it does not reflect the type correctly in swagger documentation.

In the swagger docs `[]bson.ObjectId` becomes `[{}]` when it should reflect as `["string"]`

This PR allows you to use `[]` with the `type` tag to override custom types as slices/arrays instead of just basic types.

e.g `type:"[]string"` will result in `["string"]` for your model documentation.