### PR TITLE
no request content cache in v2

### DIFF
--- a/compress_test.go
+++ b/compress_test.go
@@ -94,7 +94,6 @@ func TestGzipDecompressRequestBody(t *testing.T) {
 	httpRequest.Header.Set("Content-Encoding", "gzip")
 	req.Request = httpRequest
 
-	doCacheReadEntityBytes = false
 	doc := make(map[string]interface{})
 	req.ReadEntity(&doc)
 
@@ -117,7 +116,6 @@ func TestZlibDecompressRequestBody(t *testing.T) {
 	httpRequest.Header.Set("Content-Encoding", "deflate")
 	req.Request = httpRequest
 
-	doCacheReadEntityBytes = false
 	doc := make(map[string]interface{})
 	req.ReadEntity(&doc)
 

--- a/doc.go
+++ b/doc.go
@@ -157,11 +157,6 @@ DoNotRecover controls whether panics will be caught to return HTTP 500.
 If set to true, Route functions are responsible for handling any error situation.
 Default value is false; it will recover from panics. This has performance implications.
 
-	restful.SetCacheReadEntity(false)
-
-SetCacheReadEntity controls whether the response data ([]byte) is cached such that ReadEntity is repeatable.
-If you expect to read large amounts of payload data, and you do not use this feature, you should set it to false.
-
 	restful.SetCompressorProvider(NewBoundedCachedCompressors(20, 20))
 
 If content encoding is enabled then the default strategy for getting new gzip/zlib writers and readers is to use a sync.Pool.

--- a/request.go
+++ b/request.go
@@ -13,12 +13,9 @@ import (
 
 var defaultRequestContentType string
 
-var doCacheReadEntityBytes = true
-
 // Request is a wrapper for a http Request that provides convenience methods
 type Request struct {
 	Request           *http.Request
-	bodyContent       *[]byte // to cache the request body for multiple reads of ReadEntity
 	pathParameters    map[string]string
 	attributes        map[string]interface{} // for storing request-scoped values
 	selectedRoutePath string                 // root path + route path that matched the request, e.g. /meetings/{id}/attendees
@@ -39,12 +36,6 @@ func NewRequest(httpRequest *http.Request) *Request {
 // 	restful.DefaultRequestContentType(restful.MIME_JSON)
 func DefaultRequestContentType(mime string) {
 	defaultRequestContentType = mime
-}
-
-// SetCacheReadEntity controls whether the response data ([]byte) is cached such that ReadEntity is repeatable.
-// Default is true (due to backwardcompatibility). For better performance, you should set it to false if you don't need it.
-func SetCacheReadEntity(doCache bool) {
-	doCacheReadEntityBytes = doCache
 }
 
 // PathParameter accesses the Path parameter value by its name
@@ -80,18 +71,6 @@ func (r *Request) HeaderParameter(name string) string {
 func (r *Request) ReadEntity(entityPointer interface{}) (err error) {
 	contentType := r.Request.Header.Get(HEADER_ContentType)
 	contentEncoding := r.Request.Header.Get(HEADER_ContentEncoding)
-
-	// OLD feature, cache the body for reads
-	if doCacheReadEntityBytes {
-		if r.bodyContent == nil {
-			data, err := ioutil.ReadAll(r.Request.Body)
-			if err != nil {
-				return err
-			}
-			r.bodyContent = &data
-		}
-		r.Request.Body = ioutil.NopCloser(bytes.NewReader(*r.bodyContent))
-	}
 
 	// check if the request body needs decompression
 	if ENCODING_GZIP == contentEncoding {

--- a/request_test.go
+++ b/request_test.go
@@ -29,8 +29,7 @@ type Sample struct {
 	Value string
 }
 
-func TestReadEntityXmlCached(t *testing.T) {
-	SetCacheReadEntity(true)
+func TestReadEntityXml(t *testing.T) {
 	bodyReader := strings.NewReader("<Sample><Value>42</Value></Sample>")
 	httpRequest, _ := http.NewRequest("GET", "/test", bodyReader)
 	httpRequest.Header.Set("Content-Type", "application/xml")
@@ -39,25 +38,6 @@ func TestReadEntityXmlCached(t *testing.T) {
 	request.ReadEntity(sam)
 	if sam.Value != "42" {
 		t.Fatal("read failed")
-	}
-	if request.bodyContent == nil {
-		t.Fatal("no expected cached bytes found")
-	}
-}
-
-func TestReadEntityXmlNonCached(t *testing.T) {
-	SetCacheReadEntity(false)
-	bodyReader := strings.NewReader("<Sample><Value>42</Value></Sample>")
-	httpRequest, _ := http.NewRequest("GET", "/test", bodyReader)
-	httpRequest.Header.Set("Content-Type", "application/xml")
-	request := &Request{Request: httpRequest}
-	sam := new(Sample)
-	request.ReadEntity(sam)
-	if sam.Value != "42" {
-		t.Fatal("read failed")
-	}
-	if request.bodyContent != nil {
-		t.Fatal("unexpected cached bytes found")
 	}
 }
 
@@ -86,37 +66,6 @@ func TestReadEntityJsonCharset(t *testing.T) {
 }
 
 func TestReadEntityJsonNumber(t *testing.T) {
-	SetCacheReadEntity(true)
-	bodyReader := strings.NewReader(`{"Value" : 4899710515899924123}`)
-	httpRequest, _ := http.NewRequest("GET", "/test", bodyReader)
-	httpRequest.Header.Set("Content-Type", "application/json")
-	request := &Request{Request: httpRequest}
-	any := make(Anything)
-	request.ReadEntity(&any)
-	number, ok := any["Value"].(json.Number)
-	if !ok {
-		t.Fatal("read failed")
-	}
-	vint, err := number.Int64()
-	if err != nil {
-		t.Fatal("convert failed")
-	}
-	if vint != 4899710515899924123 {
-		t.Fatal("read failed")
-	}
-	vfloat, err := number.Float64()
-	if err != nil {
-		t.Fatal("convert failed")
-	}
-	// match the default behaviour
-	vstring := strconv.FormatFloat(vfloat, 'e', 15, 64)
-	if vstring != "4.899710515899924e+18" {
-		t.Fatal("convert float64 failed")
-	}
-}
-
-func TestReadEntityJsonNumberNonCached(t *testing.T) {
-	SetCacheReadEntity(false)
 	bodyReader := strings.NewReader(`{"Value" : 4899710515899924123}`)
 	httpRequest, _ := http.NewRequest("GET", "/test", bodyReader)
 	httpRequest.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
@emicklei According to what we have talked  here #306, I open this PR to disable request content cache, I want to make sure this is just what we want, then I will add an example to show how we can implement the same with filter. PTAL. Besides should we create a new v2 branch, or we just use master branch?
