### PR TITLE
Accept pointers passed to model builder for swagger

### DIFF
--- a/swagger/model_builder.go
+++ b/swagger/model_builder.go
@@ -43,6 +43,12 @@ func (b modelBuilder) addModelFrom(sample interface{}) {
 }
 
 func (b modelBuilder) addModel(st reflect.Type, nameOverride string) *Model {
+	// Turn pointers into simpler types so further checks are
+	// correct.
+	if st.Kind() == reflect.Ptr {
+		st = st.Elem()
+	}
+
 	modelName := b.keyFrom(st)
 	if nameOverride != "" {
 		modelName = nameOverride

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -860,7 +860,7 @@ func TestRegion_Issue113(t *testing.T) {
   "||swagger.Region": {
    "id": "||swagger.Region",
    "properties": {}
-  },		
+  },
   "swagger.Region": {
    "id": "swagger.Region",
    "required": [
@@ -919,6 +919,25 @@ func TestIssue158(t *testing.T) {
   }
  }`
 	testJsonFromStruct(t, Customer{}, expected)
+}
+
+func TestPointers(t *testing.T) {
+	type Vote struct {
+		What YesNo
+	}
+	testJsonFromStruct(t, &Vote{}, `{
+  "swagger.Vote": {
+   "id": "swagger.Vote",
+   "required": [
+    "What"
+   ],
+   "properties": {
+    "What": {
+     "type": "string"
+    }
+   }
+  }
+ }`)
 }
 
 func TestSlices(t *testing.T) {


### PR DESCRIPTION
From a model perspective we treat `type.Struct` and `*type.Struct`
identically when nested, but if `*type.Struct` is passed to go-restful
via `.Writes()`. Since these are expected to be models, this is more
friendly to integrators.

Added test of passing a struct by pointer.