### PR TITLE
Support renaming model type names holistically

### DIFF
--- a/swagger/config.go
+++ b/swagger/config.go
@@ -2,6 +2,7 @@ package swagger
 
 import (
 	"net/http"
+	"reflect"
 
 	"github.com/emicklei/go-restful"
 )
@@ -9,7 +10,12 @@ import (
 // PostBuildDeclarationMapFunc can be used to modify the api declaration map.
 type PostBuildDeclarationMapFunc func(apiDeclarationMap *ApiDeclarationList)
 
+// MapSchemaFormatFunc can be used to modify typeName at definition time.
 type MapSchemaFormatFunc func(typeName string) string
+
+// MapModelTypeNameFunc can be used to return the desired typeName for a given
+// type. It will return false if the default name should be used.
+type MapModelTypeNameFunc func(t reflect.Type) (string, bool)
 
 type Config struct {
 	// url where the services are available, e.g. http://localhost:8080
@@ -33,6 +39,8 @@ type Config struct {
 	PostBuildHandler PostBuildDeclarationMapFunc
 	// Swagger global info struct
 	Info Info
-	// [optional] If set, model builder should call this handler to get addition typename-to-swagger-format-field convertion.
+	// [optional] If set, model builder should call this handler to get addition typename-to-swagger-format-field conversion.
 	SchemaFormatHandler MapSchemaFormatFunc
+	// [optional] If set, model builder should call this handler to retrieve the name for a given type.
+	ModelTypeNameHandler MapModelTypeNameFunc
 }

--- a/swagger/model_builder_test.go
+++ b/swagger/model_builder_test.go
@@ -3,6 +3,7 @@ package swagger
 import (
 	"encoding/xml"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -1234,4 +1235,49 @@ func TestXmlNameStructs(t *testing.T) {
  }
 `
 	testJsonFromStruct(t, XmlNamed{}, expected)
+}
+
+func TestNameCustomization(t *testing.T) {
+	expected := `
+{
+  "swagger.A": {
+   "id": "swagger.A",
+   "description": "A struct",
+   "required": [
+    "SB"
+   ],
+   "properties": {
+    "SB": {
+     "type": "string",
+     "description": "SB field"
+    },
+    "metadata": {
+     "$ref": "new.swagger.SpecialC1",
+     "description": "C1 field"
+    }
+   }
+  },
+  "new.swagger.SpecialC1": {
+   "id": "new.swagger.SpecialC1",
+   "description": "C1 struct",
+   "required": [
+    "SC"
+   ],
+   "properties": {
+    "SC": {
+     "type": "string",
+     "description": "SC field"
+    }
+   }
+  }
+ }`
+
+	testJsonFromStructWithConfig(t, A{}, expected, &Config{
+		ModelTypeNameHandler: func(t reflect.Type) (string, bool) {
+			if t == reflect.TypeOf(C1{}) {
+				return "new.swagger.SpecialC1", true
+			}
+			return "", false
+		},
+	})
 }


### PR DESCRIPTION
As schemas become more complicated, the odds of two types in different
packages sharing the same generated "reflect.Type#String()" value
increases (e.g. `pkg/type/v1.Event` and `pkg/history/v1.Event` will both
result in `v1.Event` as a model name). This adds a new optional function
on the swagger.Config that can remap type names before they are written
into the Swagger model. Because types must be referenced across
structures, the mapping needs to happen at all the places that convert
`reflect.Type` to `string`.

Spawned by kubernetes/kubernetes#38071 where we now have duplicate type names.

@mbohlool this will allow us to bypass this problem in the short term.