### PR TITLE
Allow body parameter type name to be customized

### DIFF
--- a/web_service.go
+++ b/web_service.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"errors"
 	"os"
+	"reflect"
 	"sync"
 
 	"github.com/emicklei/go-restful/log"
@@ -24,6 +25,8 @@ type WebService struct {
 	documentation  string
 	apiVersion     string
 
+	typeNameHandleFunc TypeNameHandleFunction
+
 	dynamicRoutes bool
 
 	// protects 'routes' if dynamic routes are enabled
@@ -32,6 +35,25 @@ type WebService struct {
 
 func (w *WebService) SetDynamicRoutes(enable bool) {
 	w.dynamicRoutes = enable
+}
+
+// TypeNameHandleFunction declares functions that can handle translating the name of a sample object
+// into the restful documentation for the service.
+type TypeNameHandleFunction func(sample interface{}) string
+
+// TypeNameHandler sets the function that will convert types to strings in the parameter
+// and model definitions. If not set, the web service will invoke
+// reflect.TypeOf(object).String().
+func (w *WebService) TypeNameHandler(handler TypeNameHandleFunction) *WebService {
+	w.typeNameHandleFunc = handler
+	return w
+}
+
+// reflectTypeName is the default TypeNameHandleFunction and for a given object
+// returns the name that Go identifies it with (e.g. "string" or "v1.Object") via
+// the reflection API.
+func reflectTypeName(sample interface{}) string {
+	return reflect.TypeOf(sample).String()
 }
 
 // compilePathExpression ensures that the path is compiled into a RegEx for those routers that need it.
@@ -174,7 +196,7 @@ func (w *WebService) RemoveRoute(path, method string) error {
 
 // Method creates a new RouteBuilder and initialize its http method
 func (w *WebService) Method(httpMethod string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method(httpMethod)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method(httpMethod)
 }
 
 // Produces specifies that this WebService can produce one or more MIME types.
@@ -239,30 +261,30 @@ func (w *WebService) Documentation() string {
 
 // HEAD is a shortcut for .Method("HEAD").Path(subPath)
 func (w *WebService) HEAD(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("HEAD").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("HEAD").Path(subPath)
 }
 
 // GET is a shortcut for .Method("GET").Path(subPath)
 func (w *WebService) GET(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("GET").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("GET").Path(subPath)
 }
 
 // POST is a shortcut for .Method("POST").Path(subPath)
 func (w *WebService) POST(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("POST").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("POST").Path(subPath)
 }
 
 // PUT is a shortcut for .Method("PUT").Path(subPath)
 func (w *WebService) PUT(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("PUT").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("PUT").Path(subPath)
 }
 
 // PATCH is a shortcut for .Method("PATCH").Path(subPath)
 func (w *WebService) PATCH(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("PATCH").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("PATCH").Path(subPath)
 }
 
 // DELETE is a shortcut for .Method("DELETE").Path(subPath)
 func (w *WebService) DELETE(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("DELETE").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("DELETE").Path(subPath)
 }

--- a/web_service_test.go
+++ b/web_service_test.go
@@ -241,6 +241,29 @@ func TestContentTypeOctet_Issue170(t *testing.T) {
 	}
 }
 
+type exampleBody struct{}
+
+func TestParameterDataTypeDefaults(t *testing.T) {
+	tearDown()
+	ws := new(WebService)
+	route := ws.POST("/post").Reads(&exampleBody{})
+	if route.parameters[0].data.DataType != "*restful.exampleBody" {
+		t.Errorf("body parameter incorrect name: %#v", route.parameters[0].data)
+	}
+}
+
+func TestParameterDataTypeCustomization(t *testing.T) {
+	tearDown()
+	ws := new(WebService)
+	ws.TypeNameHandler(func(sample interface{}) string {
+		return "my.custom.type.name"
+	})
+	route := ws.POST("/post").Reads(&exampleBody{})
+	if route.parameters[0].data.DataType != "my.custom.type.name" {
+		t.Errorf("body parameter incorrect name: %#v", route.parameters[0].data)
+	}
+}
+
 func newPanicingService() *WebService {
 	ws := new(WebService).Path("")
 	ws.Route(ws.GET("/fire").To(doPanic))


### PR DESCRIPTION
The only DataType value set outside of the swagger model builder is the
result of calling `.Reads(...)` on a Route. In order to allow someone to
properly generate a consistent Swagger doc where the default
`reflect.TypeOf().String()` call would not be unique across an API for
multiple types, add a new method to WebService to allow the caller to
define their own pattern for this.

This is a continuation of #325 and closes a gap I missed in that PR.  I tried to keep this minimal by making an optional flag added to WebService - was hoping originally to inherit from container but since WebServices are instantiated by callers and data type is resolved prior to being added to a container there was no way to accomplish that.