### PR TITLE
Additional CORS headers for OPTIONS request

### DIFF
--- a/doc_examples_test.go
+++ b/doc_examples_test.go
@@ -2,14 +2,16 @@ package restful
 
 import "net/http"
 
-func ExampleOPTIONSFilter() {
+func ExampleOptionsFilter() {
 	// Install the OPTIONS filter on the default Container
-	Filter(OPTIONSFilter())
+	optionsFilter := OptionsFilter{Container: DefaultContainer}
+	Filter(optionsFilter.Filter)
 }
-func ExampleContainer_OPTIONSFilter() {
+func ExampleContainer_OptionsFilter() {
 	// Install the OPTIONS filter on a Container
 	myContainer := new(Container)
-	myContainer.Filter(myContainer.OPTIONSFilter)
+	optionsFilter := OptionsFilter{Container: myContainer}
+	myContainer.Filter(optionsFilter.Filter)
 }
 
 func ExampleContainer() {

--- a/options_filter.go
+++ b/options_filter.go
@@ -6,21 +6,34 @@ import "strings"
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
 
-// OPTIONSFilter is a filter function that inspects the Http Request for the OPTIONS method
+// OptionsFilter is used to create a Filter that implements proper headers for CORS OPTIONS
+// requests. Cross-origin resource sharing (CORS) is a mechanism that allows JavaScript on
+// a web page to make XMLHttpRequests to another domain, not the domain the JavaScript
+// originated from.
+//
+// http://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+// http://enable-cors.org/server.html
+// http://www.html5rocks.com/en/tutorials/cors/#toc-handling-a-not-so-simple-request
+type OptionsFilter struct {
+	Container *Container
+}
+
+// Filter is a filter function that inspects the Http Request for the OPTIONS method
 // and provides the response with a set of allowed methods for the request URL Path.
-// As for any filter, you can also install it for a particular WebService within a Container.
-// Note: this filter is not needed when using CrossOriginResourceSharing (for CORS).
-func (c *Container) OPTIONSFilter(req *Request, resp *Response, chain *FilterChain) {
+// As for any filter, you can also install it for a particular WebService within a Container
+func (o *OptionsFilter) Filter(req *Request, resp *Response, chain *FilterChain) {
 	if "OPTIONS" != req.Request.Method {
 		chain.ProcessFilter(req, resp)
 		return
 	}
-	resp.AddHeader(HEADER_Allow, strings.Join(c.computeAllowedMethods(req), ","))
-}
 
-// OPTIONSFilter is a filter function that inspects the Http Request for the OPTIONS method
-// and provides the response with a set of allowed methods for the request URL Path.
-// Note: this filter is not needed when using CrossOriginResourceSharing (for CORS).
-func OPTIONSFilter() FilterFunction {
-	return DefaultContainer.OPTIONSFilter
+	archs := req.Request.Header.Get(HEADER_AccessControlRequestHeaders)
+	methods := strings.Join(o.Container.computeAllowedMethods(req), ",")
+	origin := req.Request.Header.Get(HEADER_Origin)
+
+	resp.AddHeader(HEADER_Allow, methods)
+	resp.AddHeader(HEADER_AccessControlAllowOrigin, origin)
+	resp.AddHeader(HEADER_AccessControlAllowHeaders, archs)
+	resp.AddHeader(HEADER_AccessControlAllowMethods, methods)
+
 }

--- a/options_filter_test.go
+++ b/options_filter_test.go
@@ -14,6 +14,7 @@ func TestOptionsFilter(t *testing.T) {
 	ws.Route(ws.GET("/candy/{kind}").To(dummy))
 	ws.Route(ws.DELETE("/candy/{kind}").To(dummy))
 	ws.Route(ws.POST("/candies").To(dummy))
+	ws.Route(ws.PUT("/candies").To(dummy))
 	Add(ws)
 	Filter(optionsFilter.Filter)
 
@@ -29,7 +30,8 @@ func TestOptionsFilter(t *testing.T) {
 	httpWriter = httptest.NewRecorder()
 	DefaultContainer.dispatch(httpWriter, httpRequest)
 	actual = httpWriter.Header().Get(HEADER_Allow)
-	if "POST" != actual {
-		t.Fatal("expected: POST but got:" + actual)
+	if "POST,PUT" != actual {
+		t.Fatal("expected: POST,PUT but got:" + actual)
 	}
+
 }

--- a/options_filter_test.go
+++ b/options_filter_test.go
@@ -10,11 +10,12 @@ import (
 func TestOptionsFilter(t *testing.T) {
 	tearDown()
 	ws := new(WebService)
+	optionsFilter := OptionsFilter{Container: DefaultContainer}
 	ws.Route(ws.GET("/candy/{kind}").To(dummy))
 	ws.Route(ws.DELETE("/candy/{kind}").To(dummy))
 	ws.Route(ws.POST("/candies").To(dummy))
 	Add(ws)
-	Filter(OPTIONSFilter())
+	Filter(optionsFilter.Filter)
 
 	httpRequest, _ := http.NewRequest("OPTIONS", "http://here.io/candy/gum", nil)
 	httpWriter := httptest.NewRecorder()


### PR DESCRIPTION
I created an [issue on the Mora project](https://github.com/emicklei/mora/issues/50) when I wasn't able to execute PUT requests due to a CORS violation. The following headers were missing on OPTIONS preflight responses:

- Access-Control-Allow-Headers
- Access-Control-Allow-Methods
- Access-Control-Allow-Origin

Chrome required these and their absense caused the request to get rejected. After digging around and trying to figure out how best to fix it, I came up with a solution in this project that addresses the issue. The tests have been modified to account for the change and verified. Hopefully you'll find it satisfactory. Thanks!