### PR TITLE
Add metadata to Route

### DIFF
--- a/route.go
+++ b/route.go
@@ -34,6 +34,9 @@ type Route struct {
 	ParameterDocs           []*Parameter
 	ResponseErrors          map[int]ResponseError
 	ReadSample, WriteSample interface{} // structs that model an example request or response payload
+
+	// Extra information used to store custom information about the route.
+	Metadata map[string]interface{}
 }
 
 // Initialize for Route

--- a/route_builder.go
+++ b/route_builder.go
@@ -32,6 +32,7 @@ type RouteBuilder struct {
 	readSample, writeSample interface{}
 	parameters              []*Parameter
 	errorMap                map[int]ResponseError
+	metadata                map[string]interface{}
 }
 
 // Do evaluates each argument with the RouteBuilder itself.
@@ -165,6 +166,14 @@ func (b *RouteBuilder) Returns(code int, message string, model interface{}) *Rou
 	return b
 }
 
+func (b *RouteBuilder) Metadata(key string, value interface{}) *RouteBuilder {
+	if b.metadata == nil {
+		b.metadata = map[string]interface{}{}
+	}
+	b.metadata[key] = value
+	return b
+}
+
 type ResponseError struct {
 	Code    int
 	Message string
@@ -232,7 +241,8 @@ func (b *RouteBuilder) Build() Route {
 		ParameterDocs:  b.parameters,
 		ResponseErrors: b.errorMap,
 		ReadSample:     b.readSample,
-		WriteSample:    b.writeSample}
+		WriteSample:    b.writeSample,
+		Metadata:	b.metadata}
 	route.postBuild()
 	return route
 }

--- a/route_builder_test.go
+++ b/route_builder_test.go
@@ -41,7 +41,7 @@ func TestRouteBuilder(t *testing.T) {
 	json := "application/json"
 	b := new(RouteBuilder)
 	b.To(dummy)
-	b.Path("/routes").Method("HEAD").Consumes(json).Produces(json)
+	b.Path("/routes").Method("HEAD").Consumes(json).Produces(json).Metadata("test", "test-value")
 	r := b.Build()
 	if r.Path != "/routes" {
 		t.Error("path invalid")
@@ -54,5 +54,8 @@ func TestRouteBuilder(t *testing.T) {
 	}
 	if r.Operation != "dummy" {
 		t.Error("Operation not set")
+	}
+	if r.Metadata["test"] != "test-value" {
+		t.Errorf("Metadata not set")
 	}
 }


### PR DESCRIPTION
The PR allows storing metadata with each route. This metadata will not not have any effect on routing or swagger 1.2 spec generation and will be only used by the user of the library to store more information about the route.