### PR TITLE
Use log.Fatal consistently in all examples

### DIFF
--- a/examples/restful-NCSA-logging.go
+++ b/examples/restful-NCSA-logging.go
@@ -46,7 +46,7 @@ func main() {
 	ws.Filter(NCSACommonLogFormatLogger())
 	ws.Route(ws.GET("/ping").To(hello))
 	restful.Add(ws)
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func hello(req *restful.Request, resp *restful.Response) {

--- a/examples/restful-basic-authentication.go
+++ b/examples/restful-basic-authentication.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/emicklei/go-restful"
 	"io"
+	"log"
 	"net/http"
 )
 
@@ -15,7 +16,7 @@ func main() {
 	ws := new(restful.WebService)
 	ws.Route(ws.GET("/secret").Filter(basicAuthenticate).To(secret))
 	restful.Add(ws)
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func basicAuthenticate(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {

--- a/examples/restful-form-handling.go
+++ b/examples/restful-form-handling.go
@@ -5,6 +5,7 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/gorilla/schema"
 	"io"
+	"log"
 	"net/http"
 )
 
@@ -27,7 +28,7 @@ func main() {
 	ws.Route(ws.POST("/profiles").Consumes("application/x-www-form-urlencoded").To(postAdddress))
 	ws.Route(ws.GET("/profiles").To(addresssForm))
 	restful.Add(ws)
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func postAdddress(req *restful.Request, resp *restful.Response) {

--- a/examples/restful-hello-world.go
+++ b/examples/restful-hello-world.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/emicklei/go-restful"
 	"io"
+	"log"
 	"net/http"
 )
 
@@ -14,7 +15,7 @@ func main() {
 	ws := new(restful.WebService)
 	ws.Route(ws.GET("/hello").To(hello))
 	restful.Add(ws)
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func hello(req *restful.Request, resp *restful.Response) {

--- a/examples/restful-html-template.go
+++ b/examples/restful-html-template.go
@@ -17,7 +17,7 @@ func main() {
 	ws.Route(ws.GET("/").To(home))
 	restful.Add(ws)
 	print("open browser on http://localhost:8080/\n")
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 type Message struct {

--- a/examples/restful-multi-containers.go
+++ b/examples/restful-multi-containers.go
@@ -23,7 +23,7 @@ func main() {
 	ws.Route(ws.GET("/hello").To(hello))
 	restful.Add(ws)
 	go func() {
-		http.ListenAndServe(":8080", nil)
+		log.Fatal(http.ListenAndServe(":8080", nil))
 	}()
 
 	container2 := restful.NewContainer()

--- a/examples/restful-no-cache-filter.go
+++ b/examples/restful-no-cache-filter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -16,7 +17,7 @@ func main() {
 	ws.Filter(restful.NoBrowserCacheFilter)
 	ws.Route(ws.GET("/hello").To(hello))
 	restful.Add(ws)
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func hello(req *restful.Request, resp *restful.Response) {

--- a/examples/restful-path-tail.go
+++ b/examples/restful-path-tail.go
@@ -3,6 +3,7 @@ package main
 import (
 	. "github.com/emicklei/go-restful"
 	"io"
+	"log"
 	"net/http"
 )
 
@@ -18,7 +19,7 @@ func main() {
 	Add(ws)
 
 	println("[go-restful] serve path tails from http://localhost:8080/basepath")
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func staticFromPathParam(req *Request, resp *Response) {

--- a/examples/restful-resource-functions.go
+++ b/examples/restful-resource-functions.go
@@ -59,5 +59,5 @@ func (p ProductResource) Register() {
 
 func main() {
 	ProductResource{}.Register()
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/examples/restful-serve-static.go
+++ b/examples/restful-serve-static.go
@@ -27,7 +27,7 @@ func main() {
 	restful.Add(ws)
 
 	println("[go-restful] serving files on http://localhost:8080/static from local /tmp")
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func staticFromPathParam(req *restful.Request, resp *restful.Response) {


### PR DESCRIPTION
In some examples `http.ListenAndServe(":8080", nil)` is used without `log.Fatal`, by doing so the program will exit with error status 1 when ListenAndServe fails as opposed to exiting with status 0. 