### PR TITLE
Add CollectionFormat to Parameter type.  

### DIFF
--- a/parameter.go
+++ b/parameter.go
@@ -19,7 +19,29 @@ const (
 
 	// FormParameterKind = indicator of Request parameter type "form"
 	FormParameterKind
+
+	// CollectionFormatCSV comma separated values `foo,bar`
+	CollectionFormatCSV = CollectionFormat("csv")
+
+	// CollectionFormatSSV space separated values `foo bar`
+	CollectionFormatSSV = CollectionFormat("ssv")
+
+	// CollectionFormatTSV tab separated values `foo\tbar`
+	CollectionFormatTSV = CollectionFormat("tsv")
+
+	// CollectionFormatPipes pipe separated values `foo|bar`
+	CollectionFormatPipes = CollectionFormat("pipes")
+
+	// CollectionFormatMulti corresponds to multiple parameter instances instead of multiple values for a single
+	// instance `foo=bar&foo=baz`. This is valid only for QueryParameters and FormParameters
+	CollectionFormatMulti = CollectionFormat("multi")
 )
+
+type CollectionFormat string
+
+func (cf CollectionFormat) String() string {
+	return string(cf)
+}
 
 // Parameter is for documententing the parameter used in a Http Request
 // ParameterData kinds are Path,Query and Body
@@ -36,6 +58,7 @@ type ParameterData struct {
 	AllowableValues                         map[string]string
 	AllowMultiple                           bool
 	DefaultValue                            string
+	CollectionFormat                        string
 }
 
 // Data returns the state of the Parameter
@@ -110,5 +133,11 @@ func (p *Parameter) DefaultValue(stringRepresentation string) *Parameter {
 // Description sets the description value field and returns the receiver
 func (p *Parameter) Description(doc string) *Parameter {
 	p.data.Description = doc
+	return p
+}
+
+// CollectionFormat sets the collection format for an array type
+func (p *Parameter) CollectionFormat(format CollectionFormat) *Parameter {
+	p.data.CollectionFormat = format.String()
 	return p
 }

--- a/web_service.go
+++ b/web_service.go
@@ -118,7 +118,7 @@ func (w *WebService) QueryParameter(name, description string) *Parameter {
 // QueryParameter creates a new Parameter of kind Query for documentation purposes.
 // It is initialized as not required with string as its DataType.
 func QueryParameter(name, description string) *Parameter {
-	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string"}}
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string", CollectionFormat: CollectionFormatCSV.String()}}
 	p.beQuery()
 	return p
 }


### PR DESCRIPTION
When used with `AllowMultiple(true)` this will trigger the swagger UI to build the appropriate entry component.  

For example:

![image](https://user-images.githubusercontent.com/450109/31111817-36925798-a7c5-11e7-86e8-f5acf4bc3d14.png)

An additional change is required in go-restful-openapi to populate the appropriate pieces.  I will send a PR for that if this gets merged.

