### PR TITLE
add json-iterator for go-restful

### DIFF
--- a/entity_accessors.go
+++ b/entity_accessors.go
@@ -5,9 +5,7 @@ package restful
 // that can be found in the LICENSE file.
 
 import (
-	"encoding/json"
 	"encoding/xml"
-	"io"
 	"strings"
 	"sync"
 )
@@ -127,16 +125,11 @@ type entityJSONAccess struct {
 	ContentType string
 }
 
-// JSONNewDecoderFunc can be used to inject a different configration for the json Decoder instance.
-var JSONNewDecoderFunc = func(r io.Reader) *json.Decoder {
-	decoder := json.NewDecoder(r)
-	decoder.UseNumber()
-	return decoder
-}
-
 // Read unmarshalls the value from JSON
 func (e entityJSONAccess) Read(req *Request, v interface{}) error {
-	return JSONNewDecoderFunc(req.Request.Body).Decode(v)
+	decoder := NewDecoder(req.Request.Body)
+	decoder.UseNumber()
+	return decoder.Decode(v)
 }
 
 // Write marshalls the value to JSON and set the Content-Type Header.
@@ -153,7 +146,7 @@ func writeJSON(resp *Response, status int, contentType string, v interface{}) er
 	}
 	if resp.prettyPrint {
 		// pretty output must be created and written explicitly
-		output, err := json.MarshalIndent(v, " ", " ")
+		output, err := MarshalIndent(v, " ", " ")
 		if err != nil {
 			return err
 		}
@@ -165,5 +158,5 @@ func writeJSON(resp *Response, status int, contentType string, v interface{}) er
 	// not-so-pretty
 	resp.Header().Set(HEADER_ContentType, contentType)
 	resp.WriteHeader(status)
-	return json.NewEncoder(resp).Encode(v)
+	return NewEncoder(resp).Encode(v)
 }

--- a/entity_accessors.go
+++ b/entity_accessors.go
@@ -146,7 +146,7 @@ func writeJSON(resp *Response, status int, contentType string, v interface{}) er
 	}
 	if resp.prettyPrint {
 		// pretty output must be created and written explicitly
-		output, err := MarshalIndent(v, " ", " ")
+		output, err := MarshalIndent(v, "", " ")
 		if err != nil {
 			return err
 		}

--- a/json.go
+++ b/json.go
@@ -1,0 +1,11 @@
+// +build !jsoniter
+
+package restful
+
+import "encoding/json"
+
+var (
+	MarshalIndent = json.MarshalIndent
+	NewDecoder    = json.NewDecoder
+	NewEncoder    = json.NewEncoder
+)

--- a/jsoniter.go
+++ b/jsoniter.go
@@ -1,0 +1,12 @@
+// +build jsoniter
+
+package restful
+
+import "github.com/json-iterator/go"
+
+var (
+	json          = jsoniter.ConfigCompatibleWithStandardLibrary
+	MarshalIndent = json.MarshalIndent
+	NewDecoder    = json.NewDecoder
+	NewEncoder    = json.NewEncoder
+)

--- a/response_test.go
+++ b/response_test.go
@@ -44,7 +44,7 @@ func TestMeasureContentLengthJson(t *testing.T) {
 	httpWriter := httptest.NewRecorder()
 	resp := Response{ResponseWriter: httpWriter, requestAccept: "*/*", routeProduces: []string{"*/*"}, prettyPrint: true}
 	resp.WriteAsJson(food{"apple"})
-	if resp.ContentLength() != 22 {
+	if resp.ContentLength() != 20 {
 		t.Errorf("Incorrect measured length:%d", resp.ContentLength())
 	}
 }


### PR DESCRIPTION
[json-iterator](https://github.com/json-iterator/go) is a high-performance 100% compatible drop-in replacement of "encoding/json". some go web framework already supported it, for example gin and iris etc.

use encoding/json as default json package but you can change to jsoniter by build from other tags
`go build -tags=jsoniter .`

for some api application,this is necessary.