### PR TITLE
log: Deprecate in favor of github.com/go-log/log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ language: go
 go:
   - 1.x
 
+before_install:
+  - go get -d github.com/go-log/log
+
 script: go test -v

--- a/container.go
+++ b/container.go
@@ -97,7 +97,7 @@ func (c *Container) Add(service *WebService) *Container {
 	// cannot have duplicate root paths
 	for _, each := range c.webServices {
 		if each.RootPath() == service.RootPath() {
-			log.Printf("[restful] WebService with duplicate root path detected:['%v']", each)
+			log.Printf("WebService with duplicate root path detected:['%v']", each)
 			os.Exit(1)
 		}
 	}
@@ -139,7 +139,7 @@ func (c *Container) addHandler(service *WebService, serveMux *http.ServeMux) boo
 
 func (c *Container) Remove(ws *WebService) error {
 	if c.ServeMux == http.DefaultServeMux {
-		errMsg := fmt.Sprintf("[restful] cannot remove a WebService from a Container using the DefaultServeMux: ['%v']", ws)
+		errMsg := fmt.Sprintf("cannot remove a WebService from a Container using the DefaultServeMux: ['%v']", ws)
 		log.Print(errMsg)
 		return errors.New(errMsg)
 	}
@@ -168,7 +168,7 @@ func (c *Container) Remove(ws *WebService) error {
 // This may be a security issue as it exposes sourcecode information.
 func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) {
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("[restful] recover from panic situation: - %v\r\n", panicReason))
+	buffer.WriteString(fmt.Sprintf("recover from panic situation: - %v\r\n", panicReason))
 	for i := 2; ; i += 1 {
 		_, file, line, ok := runtime.Caller(i)
 		if !ok {
@@ -228,7 +228,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 			var err error
 			writer, err = NewCompressingResponseWriter(httpWriter, encoding)
 			if err != nil {
-				log.Print("[restful] unable to install compressor: ", err)
+				log.Print("unable to install compressor: ", err)
 				httpWriter.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/container.go
+++ b/container.go
@@ -13,8 +13,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-
-	"github.com/emicklei/go-restful/log"
 )
 
 // Container holds a collection of WebServices and a http.ServeMux to dispatch http requests.
@@ -97,7 +95,7 @@ func (c *Container) Add(service *WebService) *Container {
 	// cannot have duplicate root paths
 	for _, each := range c.webServices {
 		if each.RootPath() == service.RootPath() {
-			log.Printf("WebService with duplicate root path detected:['%v']", each)
+			Logger.Logf("WebService with duplicate root path detected:['%v']", each)
 			os.Exit(1)
 		}
 	}
@@ -140,7 +138,7 @@ func (c *Container) addHandler(service *WebService, serveMux *http.ServeMux) boo
 func (c *Container) Remove(ws *WebService) error {
 	if c.ServeMux == http.DefaultServeMux {
 		errMsg := fmt.Sprintf("cannot remove a WebService from a Container using the DefaultServeMux: ['%v']", ws)
-		log.Print(errMsg)
+		Logger.Log(errMsg)
 		return errors.New(errMsg)
 	}
 	c.webServicesLock.Lock()
@@ -176,7 +174,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 		}
 		buffer.WriteString(fmt.Sprintf("    %s:%d\r\n", file, line))
 	}
-	log.Print(buffer.String())
+	Logger.Log(buffer.String())
 	httpWriter.WriteHeader(http.StatusInternalServerError)
 	httpWriter.Write(buffer.Bytes())
 }
@@ -228,7 +226,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 			var err error
 			writer, err = NewCompressingResponseWriter(httpWriter, encoding)
 			if err != nil {
-				log.Print("unable to install compressor: ", err)
+				Logger.Log("unable to install compressor: ", err)
 				httpWriter.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/cors_filter.go
+++ b/cors_filter.go
@@ -35,14 +35,14 @@ func (c CrossOriginResourceSharing) Filter(req *Request, resp *Response, chain *
 	origin := req.Request.Header.Get(HEADER_Origin)
 	if len(origin) == 0 {
 		if trace {
-			traceLogger.Print("no Http header Origin set")
+			traceLogger.Log("no Http header Origin set")
 		}
 		chain.ProcessFilter(req, resp)
 		return
 	}
 	if !c.isOriginAllowed(origin) { // check whether this origin is allowed
 		if trace {
-			traceLogger.Printf("HTTP Origin:%s is not part of %v, neither matches any part of %v", origin, c.AllowedDomains, c.allowedOriginPatterns)
+			traceLogger.Logf("HTTP Origin:%s is not part of %v, neither matches any part of %v", origin, c.AllowedDomains, c.allowedOriginPatterns)
 		}
 		chain.ProcessFilter(req, resp)
 		return
@@ -78,7 +78,7 @@ func (c *CrossOriginResourceSharing) doPreflightRequest(req *Request, resp *Resp
 	acrm := req.Request.Header.Get(HEADER_AccessControlRequestMethod)
 	if !c.isValidAccessControlRequestMethod(acrm, c.AllowedMethods) {
 		if trace {
-			traceLogger.Printf("Http header %s:%s is not in %v",
+			traceLogger.Logf("Http header %s:%s is not in %v",
 				HEADER_AccessControlRequestMethod,
 				acrm,
 				c.AllowedMethods)
@@ -90,7 +90,7 @@ func (c *CrossOriginResourceSharing) doPreflightRequest(req *Request, resp *Resp
 		for _, each := range strings.Split(acrhs, ",") {
 			if !c.isValidAccessControlRequestHeader(strings.Trim(each, " ")) {
 				if trace {
-					traceLogger.Printf("Http header %s:%s is not in %v",
+					traceLogger.Logf("Http header %s:%s is not in %v",
 						HEADER_AccessControlRequestHeaders,
 						acrhs,
 						c.AllowedHeaders)

--- a/curly.go
+++ b/curly.go
@@ -25,14 +25,14 @@ func (c CurlyRouter) SelectRoute(
 	detectedService := c.detectWebService(requestTokens, webServices)
 	if detectedService == nil {
 		if trace {
-			traceLogger.Printf("no WebService was found to match URL path:%s\n", httpRequest.URL.Path)
+			traceLogger.Logf("no WebService was found to match URL path:%s\n", httpRequest.URL.Path)
 		}
 		return nil, nil, NewError(http.StatusNotFound, "404: Page Not Found")
 	}
 	candidateRoutes := c.selectRoutes(detectedService, requestTokens)
 	if len(candidateRoutes) == 0 {
 		if trace {
-			traceLogger.Printf("no Route in WebService with path %s was found to match URL path:%s\n", detectedService.rootPath, httpRequest.URL.Path)
+			traceLogger.Logf("no Route in WebService with path %s was found to match URL path:%s\n", detectedService.rootPath, httpRequest.URL.Path)
 		}
 		return detectedService, nil, NewError(http.StatusNotFound, "404: Page Not Found")
 	}
@@ -100,7 +100,7 @@ func (c CurlyRouter) regularMatchesPathToken(routeToken string, colon int, reque
 	regPart := routeToken[colon+1 : len(routeToken)-1]
 	if regPart == "*" {
 		if trace {
-			traceLogger.Printf("wildcard parameter detected in route token %s that matches %s\n", routeToken, requestToken)
+			traceLogger.Logf("wildcard parameter detected in route token %s that matches %s\n", routeToken, requestToken)
 		}
 		return true, true
 	}

--- a/doc.go
+++ b/doc.go
@@ -156,19 +156,27 @@ Default value is true
 If content encoding is enabled then the default strategy for getting new gzip/zlib writers and readers is to use a sync.Pool.
 Because writers are expensive structures, performance is even more improved when using a preloaded cache. You can also inject your own implementation.
 
-Trouble shooting
-
-This package has the means to produce detail logging of the complete Http request matching process and filter invocation.
-Enabling this feature requires you to set an implementation of restful.StdLogger (e.g. log.Logger) instance such as:
-
-	restful.TraceLogger(log.New(os.Stdout, "[restful] ", log.LstdFlags|log.Lshortfile))
-
 Logging
 
 The restful.SetLogger() method allows you to override the logger used by the package. By default restful
 uses the standard library `log` package and logs to stdout. Different logging packages are supported as
-long as they conform to `StdLogger` interface defined in the `log` sub-package, writing an adapter for your
+long as they conform to github.com/go-log/log's Logger interface.  github.com/go-log/log's subpackages
+provide some adapters for common logging implementations, and writing additional adapters for your
 preferred package is simple.
+
+Trouble shooting
+
+This package has the means to produce detail logging of the complete HTTP request matching process and filter invocation.
+For example, to use the standard library's Logger.Logger, you could use:
+
+  import (
+    "log"
+
+    "github.com/emicklei/go-restful"
+    "github.com/go-log/log/print"
+  )
+
+	restful.TraceLogger(print.New(log.New(os.Stdout, "[restful] ", log.LstdFlags|log.Lshortfile)))
 
 Resources
 

--- a/jsr311.go
+++ b/jsr311.go
@@ -81,7 +81,7 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 	}
 	if len(ifOk) == 0 {
 		if trace {
-			traceLogger.Printf("no Route found (from %d) that passes conditional checks", len(routes))
+			traceLogger.Logf("no Route found (from %d) that passes conditional checks", len(routes))
 		}
 		return nil, NewError(http.StatusNotFound, "404: Not Found")
 	}
@@ -95,7 +95,7 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 	}
 	if len(methodOk) == 0 {
 		if trace {
-			traceLogger.Printf("no Route found (in %d routes) that matches HTTP method %s\n", len(routes), httpRequest.Method)
+			traceLogger.Logf("no Route found (in %d routes) that matches HTTP method %s\n", len(routes), httpRequest.Method)
 		}
 		return nil, NewError(http.StatusMethodNotAllowed, "405: Method Not Allowed")
 	}
@@ -111,7 +111,7 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 	}
 	if len(inputMediaOk) == 0 {
 		if trace {
-			traceLogger.Printf("no Route found (from %d) that matches HTTP Content-Type: %s\n", len(methodOk), contentType)
+			traceLogger.Logf("no Route found (from %d) that matches HTTP Content-Type: %s\n", len(methodOk), contentType)
 		}
 		return nil, NewError(http.StatusUnsupportedMediaType, "415: Unsupported Media Type")
 	}
@@ -129,7 +129,7 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 	}
 	if len(outputMediaOk) == 0 {
 		if trace {
-			traceLogger.Printf("no Route found (from %d) that matches HTTP Accept: %s\n", len(inputMediaOk), accept)
+			traceLogger.Logf("no Route found (from %d) that matches HTTP Accept: %s\n", len(inputMediaOk), accept)
 		}
 		return nil, NewError(http.StatusNotAcceptable, "406: Not Acceptable")
 	}
@@ -160,7 +160,7 @@ func (r RouterJSR311) selectRoutes(dispatcher *WebService, pathRemainder string)
 	}
 	if len(filtered.candidates) == 0 {
 		if trace {
-			traceLogger.Printf("WebService on path %s has no routes that match URL path remainder:%s\n", dispatcher.rootPath, pathRemainder)
+			traceLogger.Logf("WebService on path %s has no routes that match URL path remainder:%s\n", dispatcher.rootPath, pathRemainder)
 		}
 		return []Route{}
 	}
@@ -189,7 +189,7 @@ func (r RouterJSR311) detectDispatcher(requestPath string, dispatchers []*WebSer
 	}
 	if len(filtered.candidates) == 0 {
 		if trace {
-			traceLogger.Printf("no WebService was found to match URL path:%s\n", requestPath)
+			traceLogger.Logf("no WebService was found to match URL path:%s\n", requestPath)
 		}
 		return nil, "", errors.New("not found")
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -1,8 +1,9 @@
+// Package log is deprecated.  Please use restful.SetLogLogger instead.
 package log
 
 import (
-	stdlog "log"
-	"os"
+	"github.com/emicklei/go-restful"
+	"github.com/go-log/log/print"
 )
 
 // StdLogger corresponds to a minimal subset of the interface satisfied by stdlib log.Logger
@@ -11,24 +12,23 @@ type StdLogger interface {
 	Printf(format string, v ...interface{})
 }
 
-var Logger StdLogger
-
-func init() {
-	// default Logger
-	SetLogger(stdlog.New(os.Stderr, "[restful] ", stdlog.LstdFlags|stdlog.Lshortfile))
-}
-
 // SetLogger sets the logger for this package
+//
+// Deprecated: Please set restful.Logger instead.
 func SetLogger(customLogger StdLogger) {
-	Logger = customLogger
+	restful.Logger = print.New(customLogger)
 }
 
 // Print delegates to the Logger
+//
+// Deprecated: Please use restful.Logger.Log instead.
 func Print(v ...interface{}) {
-	Logger.Print(v...)
+	restful.Logger.Log(v...)
 }
 
 // Printf delegates to the Logger
+//
+// Deprecated: Please use restful.Logger.Logf instead.
 func Printf(format string, v ...interface{}) {
-	Logger.Printf(format, v...)
+	restful.Logger.Logf(format, v...)
 }

--- a/logger.go
+++ b/logger.go
@@ -4,26 +4,48 @@ package restful
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
 import (
-	"github.com/emicklei/go-restful/log"
+	stdlog "log"
+	"os"
+
+	"github.com/go-log/log"
+	"github.com/go-log/log/print"
 )
 
-var trace bool = false
-var traceLogger log.StdLogger
+var (
+	// Logger is the package-wide logger.
+	Logger log.Logger
+
+	trace bool = false
+	traceLogger log.Logger
+)
 
 func init() {
-	traceLogger = log.Logger // use the package logger by default
+	Logger = print.New(stdlog.New(os.Stderr, "[restful] ", stdlog.LstdFlags|stdlog.Lshortfile))
+	traceLogger = Logger
 }
 
-// TraceLogger enables detailed logging of Http request matching and filter invocation. Default no logger is set.
+// TraceLogger enables detailed logging of HTTP request matching and filter invocation. Default no logger is set.
 // You may call EnableTracing() directly to enable trace logging to the package-wide logger.
-func TraceLogger(logger log.StdLogger) {
+//
+// Deprecated: Please use TraceLogLogger(print.New(logger)) instead, with New from github.com/go-log/log/print.
+func TraceLogger(logger print.Printer) {
+	TraceLogLogger(print.New(logger))
+}
+
+// TraceLogLogger enables detailed logging of HTTP request matching and filter invocation. Default no logger is set.
+// You may call EnableTracing() directly to enable trace logging to the package-wide logger.
+func TraceLogLogger(logger log.Logger) {
 	traceLogger = logger
 	EnableTracing(logger != nil)
 }
 
-// SetLogger exposes the setter for the global logger on the top-level package
-func SetLogger(customLogger log.StdLogger) {
-	log.SetLogger(customLogger)
+// SetLogger sets the package-wide logger.
+//
+// Deprecated: Please set Logger instead.  If you need to convert from
+// an implementation that provides Print and Printf, use
+// github.com/go-log/log/print's New().
+func SetLogger(customLogger print.Printer) {
+	Logger = print.New(customLogger)
 }
 
 // EnableTracing can be used to Trace logging on and off.

--- a/mime.go
+++ b/mime.go
@@ -34,7 +34,7 @@ func sortedMimes(accept string) (sorted []mime) {
 			if len(parts) == 2 {
 				f, err := strconv.ParseFloat(parts[1], 64)
 				if err != nil {
-					traceLogger.Printf("unable to parse quality in %s, %v", each, err)
+					traceLogger.Logf("unable to parse quality in %s, %v", each, err)
 				} else {
 					sorted = insertMime(sorted, mime{typeAndQuality[0], f})
 				}

--- a/response.go
+++ b/response.go
@@ -117,7 +117,7 @@ func (r *Response) EntityWriter() (EntityReaderWriter, bool) {
 			}
 		}
 		if trace {
-			traceLogger.Printf("no registered EntityReaderWriter found for %s", r.requestAccept)
+			traceLogger.Logf("no registered EntityReaderWriter found for %s", r.requestAccept)
 		}
 	}
 	return writer, ok
@@ -204,7 +204,7 @@ func (r *Response) Flush() {
 	if f, ok := r.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	} else if trace {
-		traceLogger.Printf("ResponseWriter %v doesn't support Flush", r)
+		traceLogger.Logf("ResponseWriter %v doesn't support Flush", r)
 	}
 }
 

--- a/route_builder.go
+++ b/route_builder.go
@@ -261,11 +261,11 @@ func (b *RouteBuilder) typeNameHandler(handler TypeNameHandleFunction) *RouteBui
 func (b *RouteBuilder) Build() Route {
 	pathExpr, err := newPathExpression(b.currentPath)
 	if err != nil {
-		log.Printf("[restful] Invalid path:%s because:%v", b.currentPath, err)
+		log.Printf("Invalid path:%s because:%v", b.currentPath, err)
 		os.Exit(1)
 	}
 	if b.function == nil {
-		log.Printf("[restful] No function specified for route:" + b.currentPath)
+		log.Printf("No function specified for route:" + b.currentPath)
 		os.Exit(1)
 	}
 	operationName := b.operation

--- a/route_builder.go
+++ b/route_builder.go
@@ -11,8 +11,6 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
-
-	"github.com/emicklei/go-restful/log"
 )
 
 // RouteBuilder is a helper to construct Routes.
@@ -153,7 +151,7 @@ func (b *RouteBuilder) Operation(name string) *RouteBuilder {
 
 // ReturnsError is deprecated, use Returns instead.
 func (b *RouteBuilder) ReturnsError(code int, message string, model interface{}) *RouteBuilder {
-	log.Print("ReturnsError is deprecated, use Returns instead.")
+	Logger.Log("ReturnsError is deprecated, use Returns instead.")
 	return b.Returns(code, message, model)
 }
 
@@ -261,11 +259,11 @@ func (b *RouteBuilder) typeNameHandler(handler TypeNameHandleFunction) *RouteBui
 func (b *RouteBuilder) Build() Route {
 	pathExpr, err := newPathExpression(b.currentPath)
 	if err != nil {
-		log.Printf("Invalid path:%s because:%v", b.currentPath, err)
+		Logger.Logf("Invalid path:%s because:%v", b.currentPath, err)
 		os.Exit(1)
 	}
 	if b.function == nil {
-		log.Printf("No function specified for route:" + b.currentPath)
+		Logger.Logf("No function specified for route:" + b.currentPath)
 		os.Exit(1)
 	}
 	operationName := b.operation

--- a/web_service.go
+++ b/web_service.go
@@ -60,7 +60,7 @@ func reflectTypeName(sample interface{}) string {
 func (w *WebService) compilePathExpression() {
 	compiled, err := newPathExpression(w.rootPath)
 	if err != nil {
-		log.Printf("[restful] invalid path:%s because:%v", w.rootPath, err)
+		log.Printf("invalid path:%s because:%v", w.rootPath, err)
 		os.Exit(1)
 	}
 	w.pathExpr = compiled

--- a/web_service.go
+++ b/web_service.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"reflect"
 	"sync"
-
-	"github.com/emicklei/go-restful/log"
 )
 
 // Copyright 2013 Ernest Micklei. All rights reserved.
@@ -60,7 +58,7 @@ func reflectTypeName(sample interface{}) string {
 func (w *WebService) compilePathExpression() {
 	compiled, err := newPathExpression(w.rootPath)
 	if err != nil {
-		log.Printf("invalid path:%s because:%v", w.rootPath, err)
+		Logger.Logf("invalid path:%s because:%v", w.rootPath, err)
 		os.Exit(1)
 	}
 	w.pathExpr = compiled


### PR DESCRIPTION
Builds on #381; review that first.

go-restful's Logger interface is from b80aca09 (#188), at which point the interface included both the `Print` and `Fatal` method families.  That interface moved to the log subpackage in 18c1d52a (#192).  And the interface was reduced to just `Print` and `Printf` in a40a6af9 (#194), but the interface is clearly not go-restful-specific.

More recently, [github.com/go-log/log][1] ([godocs][2]) was created as a stand-alone package with a similar interface (it has `Log` and `Logf` instead of `Print` and `Printf`).  Just this morning, go-log grew [a subpackage to convert from `Print`/`Printf` to `Log`/`Logf`][3].  That means we can offload our generic-logger shim to go-log, save a few lines of generic code here (after removing the deprecated code), and automatically benefit from go-logs other implementations (e.g. you can use [`info.New`][4] to plug in a logger based on [glog's `Verbose`][5]).

I've deprecated the old interfaces, but kept them around to facilitate migrations to the new approach.  The only breaking change should be the removal of `log.Logger`, so that folks who are setting that directly (vs. going through one of the two `SetLogger` functions) will get compile-time errors and notice that they have to update their usage.  If we don't mind jumping through a few extra hoops, we could keep `log.Logger` around for now and stage migration with:

Phase 1:

* Replace the public `restful.Logger` with a `restful.SetLogLogger` setter, that takes a go-log (`Log`/`Logf`) interface.
* Calling `restful.SetLogger`, `restful.SetLogLogger`, or `log.SetLogger` will all set `log.Logger`.  We'd need a `Log`/`Logf` -> `Print`/`Printf` shim for `SetLogLogger`.
* Keep importing go-restful/log and using `log.Print` and `log.Printf` where I'm currently using `Logger.Log` and `Logger.Logf`.

Phase 2:

* Drop go-restful/log and the other interfaces deprecated in this commit.
* Replace the removed `log.Logger` global with a new `restful.Logger`.
* Replace the `log.Print` and `log.Printf` calls with `Logger.Log` and `Logger.Logf`.
* Deprecate `SetLogLogger`.

Phase 3:

* Drop `SetLogLogger`.

Alternatively, you could make the global private (`restful.logger`) and keep `SetLogLogger`.  But I expect the go-log `Logger` interface to be stable enough that we don't need to hide it behind a setter, expecially one with as ugly a name as `SetLogLogger`, or `SetLogger2`, or whatever ;).  So my first take at this PR just drops `log.Logger` immediately to set us up for a simpler, two-phase migration (where phase 2 is just "drop all the deprecated stuff").

I also see that there's a [move-log branch][6] (without an associated PR) doing some similar log-subpackage shuffling.  As of d8185d6c, that branch is removing the log subpackage entirely, so maybe my backwards compat concerns are overblown ;).

[1]: https://github.com/go-log/log
[2]: https://godoc.org/github.com/go-log/log
[3]: https://godoc.org/github.com/go-log/log/print#New
[4]: https://godoc.org/github.com/go-log/log/info#New
[5]: https://godoc.org/github.com/golang/glog#Verbose
[6]: https://github.com/emicklei/go-restful/tree/move-log