### PR TITLE
Add support for disabling HTML escaping behavior in JSON encoder

### DIFF
--- a/entity_accessors.go
+++ b/entity_accessors.go
@@ -144,19 +144,14 @@ func writeJSON(resp *Response, status int, contentType string, v interface{}) er
 		// do not write a nil representation
 		return nil
 	}
+	enc := NewEncoder(resp)
 	if resp.prettyPrint {
-		// pretty output must be created and written explicitly
-		output, err := MarshalIndent(v, "", " ")
-		if err != nil {
-			return err
-		}
-		resp.Header().Set(HEADER_ContentType, contentType)
-		resp.WriteHeader(status)
-		_, err = resp.Write(output)
-		return err
+		enc.SetIndent("", " ")
 	}
-	// not-so-pretty
+	if !resp.jsonEscapeHTML {
+		enc.SetEscapeHTML(false)
+	}
 	resp.Header().Set(HEADER_ContentType, contentType)
 	resp.WriteHeader(status)
-	return NewEncoder(resp).Encode(v)
+	return enc.Encode(v)
 }

--- a/response.go
+++ b/response.go
@@ -17,23 +17,28 @@ var DefaultResponseMimeType string
 //PrettyPrintResponses controls the indentation feature of XML and JSON serialization
 var PrettyPrintResponses = true
 
+// JSONEscapeHTMLResponses controls whether to escape <, >, and & in JSON Encoder
+// Default value is true as encoding/json standard library, as well as go-iterator
+var JSONEscapeHTMLResponses = true
+
 // Response is a wrapper on the actual http ResponseWriter
 // It provides several convenience methods to prepare and write response content.
 type Response struct {
 	http.ResponseWriter
-	requestAccept string        // mime-type what the Http Request says it wants to receive
-	routeProduces []string      // mime-types what the Route says it can produce
-	statusCode    int           // HTTP status code that has been written explicitly (if zero then net/http has written 200)
-	contentLength int           // number of bytes written for the response body
-	prettyPrint   bool          // controls the indentation feature of XML and JSON serialization. It is initialized using var PrettyPrintResponses.
-	err           error         // err property is kept when WriteError is called
-	hijacker      http.Hijacker // if underlying ResponseWriter supports it
+	requestAccept  string        // mime-type what the Http Request says it wants to receive
+	routeProduces  []string      // mime-types what the Route says it can produce
+	statusCode     int           // HTTP status code that has been written explicitly (if zero then net/http has written 200)
+	contentLength  int           // number of bytes written for the response body
+	prettyPrint    bool          // controls the indentation feature of XML and JSON serialization. It is initialized using var PrettyPrintResponses.
+	jsonEscapeHTML bool          // controls whether to escape <, >, and & in JSON Encoder. It is initialized using var JSONEscapeHTMLResponses.
+	err            error         // err property is kept when WriteError is called
+	hijacker       http.Hijacker // if underlying ResponseWriter supports it
 }
 
 // NewResponse creates a new response based on a http ResponseWriter.
 func NewResponse(httpWriter http.ResponseWriter) *Response {
 	hijacker, _ := httpWriter.(http.Hijacker)
-	return &Response{ResponseWriter: httpWriter, routeProduces: []string{}, statusCode: http.StatusOK, prettyPrint: PrettyPrintResponses, hijacker: hijacker}
+	return &Response{ResponseWriter: httpWriter, routeProduces: []string{}, statusCode: http.StatusOK, prettyPrint: PrettyPrintResponses, jsonEscapeHTML: JSONEscapeHTMLResponses, hijacker: hijacker}
 }
 
 // DefaultResponseContentType set a default.
@@ -65,6 +70,11 @@ func (r *Response) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 // PrettyPrint changes whether this response must produce pretty (line-by-line, indented) JSON or XML output.
 func (r *Response) PrettyPrint(bePretty bool) {
 	r.prettyPrint = bePretty
+}
+
+// JSONEscapeHTML changes whether to escape the <, > and &
+func (r *Response) JSONEscapeHTML(jsonEscape bool) {
+	r.jsonEscapeHTML = jsonEscape
 }
 
 // AddHeader is a shortcut for .Header().Add(header,value)

--- a/response_test.go
+++ b/response_test.go
@@ -211,3 +211,33 @@ func TestWriteEntityNoAcceptMatchNoProduces(t *testing.T) {
 		t.Errorf("got %d want %d", httpWriter.Code, http.StatusNotAcceptable)
 	}
 }
+
+// go test -v -test.run TestWriteEntityJSONEscapeHTML ...restful
+func TestWriteEntityJSONEscapeHTMLEnabled(t *testing.T) {
+	httpWriter := httptest.NewRecorder()
+	resp := Response{ResponseWriter: httpWriter, requestAccept: "application/json", routeProduces: []string{"application/json"}, prettyPrint: true, jsonEscapeHTML: true}
+	var pong = struct {
+		Foo  string `json:"foo"`
+		Link string `json:"link"`
+	}{Foo: "123", Link: "http://www.google.com/search?q=foo&q=bar"}
+	resp.WriteHeaderAndEntity(200, pong)
+	if strings.Contains(httpWriter.Body.String(), "&") {
+		t.Errorf("expected link escaped in json:%s", httpWriter.Body.String())
+	}
+}
+
+// go test -v -test.run TestWriteEntityJSONEscapeHTMLDisabled ...restful
+func TestWriteEntityJSONEscapeHTMLDisabled(t *testing.T) {
+	httpWriter := httptest.NewRecorder()
+	resp := Response{ResponseWriter: httpWriter, requestAccept: "application/json", routeProduces: []string{"application/json"}, prettyPrint: true, jsonEscapeHTML: true}
+	// Disable HTML escaping
+	resp.JSONEscapeHTML(false)
+	var pong = struct {
+		Foo  string `json:"foo"`
+		Link string `json:"link"`
+	}{Foo: "123", Link: "http://www.google.com/search?q=foo&q=bar"}
+	resp.WriteHeaderAndEntity(200, pong)
+	if !strings.Contains(httpWriter.Body.String(), "&") {
+		t.Errorf("expected link not escaped in json:%s", httpWriter.Body.String())
+	}
+}


### PR DESCRIPTION
Currently there is no convenient way to disable HTML escaping for JSON rendering. 

By default, both `encoding/json` and `jsoniter-go` libraries are going to escape `<`, `>` and `&` to keep some browsers from misinterpreting JSON output as HTML. While this default behavior is not suitable for retrieving URLs which use the ampersand `&`to separate multiple query parameters. So the URL in JSON strings `http://www.google.com/search?q=foo&q=bar` will be escaped to `http://www.google.com/search?q=foo\u0026q=bar`. 

So as to provide an easy way to solve this, some changes are proposed in this pr:
* Add a global variable `JSONEscapeHTMLResponses` with a default `true` value to control the HTML escaping behavior of all the reponses
* Add a property named `jsonEscapeHTML` (as well as its setter method) in `Response` for per response behavior controlling
* Add the corresponding logic in `writeJSON` method
