### PR TITLE
#389 the route can now override the container.contentEncodingEnabled flag

### DIFF
--- a/route.go
+++ b/route.go
@@ -45,6 +45,9 @@ type Route struct {
 
 	// marks a route as deprecated
 	Deprecated bool
+
+	//Overrides the container.contentEncodingEnabled
+	contentEncodingEnabled *bool
 }
 
 // Initialize for Route
@@ -146,4 +149,9 @@ func tokenizePath(path string) []string {
 // for debugging
 func (r Route) String() string {
 	return r.Method + " " + r.Path
+}
+
+// EnableContentEncoding (default=false) allows for GZIP or DEFLATE encoding of responses. Overrides the container.contentEncodingEnabled value.
+func (r Route) EnableContentEncoding(enabled bool) {
+	r.contentEncodingEnabled = &enabled
 }


### PR DESCRIPTION
If set, the new route flag will override the compression setting used by the container. 

It solved the double-compression issue, or you can add auto compression just for specific routes. 