### PR TITLE
Avoid return of 415 Unsupported Media Type when request body is empty

### DIFF
--- a/jsr311.go
+++ b/jsr311.go
@@ -114,7 +114,9 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 		if trace {
 			traceLogger.Printf("no Route found (from %d) that matches HTTP Content-Type: %s\n", len(previous), contentType)
 		}
-		return nil, NewError(http.StatusUnsupportedMediaType, "415: Unsupported Media Type")
+		if httpRequest.ContentLength > 0 {
+			return nil, NewError(http.StatusUnsupportedMediaType, "415: Unsupported Media Type")
+		}
 	}
 
 	// accept


### PR DESCRIPTION
In [JSR-311](https://download.oracle.com/otn-pub/jcp/jaxrs-1.0-fr-eval-oth-JSpec/jaxrs-1.0-final-spec.pdf?AuthParam=1553798515_382f64a715f97ddc0e38865c4e4f9b0f) there is this sentence:

> The media type of the request entity body (if any) is a supported input data format (see1section 3.5). If no methods support the media type of the request entity body an implemen-2tation MUST generate aWebApplicationExceptionwith an unsupported media type3response (HTTP 415 status) and no entity. The exception MUST be processed as described4in section 3.3.4.

The current implementation ignore the *if any* in parentheses, what happen is that if you make a `POST` request without body and without `Content-Type` header you receive a `415 - Unsupported Media Type`, but looking at the specification it say that the body is optional, and need only to return 415 when the body is set.

With this PR status code 415 is received only when the `ContentLength > 0`