### PR TITLE
fix compile error for example/restful-serve-static.go

### DIFF
--- a/examples/restful-serve-static.go
+++ b/examples/restful-serve-static.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"path"
 


### PR DESCRIPTION
missing log package, which contributes to a compile error