### PR TITLE
handle path params with prefixes and suffixes

### DIFF
--- a/path_processor.go
+++ b/path_processor.go
@@ -2,6 +2,7 @@ package restful
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 )
 
@@ -34,7 +35,7 @@ func (d defaultPathProcessor) ExtractParameters(r *Route, _ *WebService, urlPath
 			value = removeCustomVerb(value)
 		}
 
-		if strings.HasPrefix(key, "{") { // path-parameter
+		if strings.Index(key, "{") > -1 { // path-parameter
 			if colon := strings.Index(key, ":"); colon != -1 {
 				// extract by regex
 				regPart := key[colon+1 : len(key)-1]
@@ -47,7 +48,14 @@ func (d defaultPathProcessor) ExtractParameters(r *Route, _ *WebService, urlPath
 				}
 			} else {
 				// without enclosing {}
-				pathParameters[key[1:len(key)-1]] = value
+				startIndex := strings.Index(key, "{")
+				endIndex := strings.Index(key, "}")
+
+				extractValuePattern := regexp.QuoteMeta(key[:startIndex]) + `(.*)` + regexp.QuoteMeta(key[endIndex+1:])
+				extractValueReg := regexp.MustCompile(extractValuePattern)
+
+				value = extractValueReg.FindStringSubmatch(value)[1]
+				pathParameters[key[startIndex+1:endIndex]] = value
 			}
 		}
 	}

--- a/path_processor.go
+++ b/path_processor.go
@@ -2,7 +2,6 @@ package restful
 
 import (
 	"bytes"
-	"regexp"
 	"strings"
 )
 
@@ -49,13 +48,12 @@ func (d defaultPathProcessor) ExtractParameters(r *Route, _ *WebService, urlPath
 			} else {
 				// without enclosing {}
 				startIndex := strings.Index(key, "{")
-				endIndex := strings.Index(key, "}")
+				endKeyIndex := strings.Index(key, "}")
 
-				extractValuePattern := regexp.QuoteMeta(key[:startIndex]) + `(.*)` + regexp.QuoteMeta(key[endIndex+1:])
-				extractValueReg := regexp.MustCompile(extractValuePattern)
+				suffixLength := len(key) - endKeyIndex - 1
+				endValueIndex := len(value) - suffixLength
 
-				value = extractValueReg.FindStringSubmatch(value)[1]
-				pathParameters[key[startIndex+1:endIndex]] = value
+				pathParameters[key[startIndex+1:endKeyIndex]] = value[startIndex:endValueIndex]
 			}
 		}
 	}

--- a/path_processor_test.go
+++ b/path_processor_test.go
@@ -67,6 +67,13 @@ func TestExtractParameters_Suffix(t *testing.T) {
 	}
 }
 
+func TestExtractParameters_Mixed(t *testing.T) {
+	params := doExtractParams("/fixed/foo_{var}_bar", 2, "/fixed/foo_barrr_bar", t)
+	if params["var"] != "barrr" {
+		t.Errorf("parameter mismatch var")
+	}
+}
+
 func TestExtractParameters_RegexAndCustomVerb(t *testing.T) {
 	testCase := []struct {
 		route     string

--- a/path_processor_test.go
+++ b/path_processor_test.go
@@ -44,6 +44,27 @@ func TestExtractParameters_EmptyValue(t *testing.T) {
 	}
 }
 
+func TestExtractParameters_Dot(t *testing.T) {
+	params := doExtractParams("/fixed/{var}.foo", 2, "/fixed/barrr.foo", t)
+	if params["var"] != "barrr" {
+		t.Errorf("parameter mismatch var")
+	}
+}
+
+func TestExtractParameters_Prefix(t *testing.T) {
+	params := doExtractParams("/fixed/foo_{var}", 2, "/fixed/foo_barrr", t)
+	if params["var"] != "barrr" {
+		t.Errorf("parameter mismatch var")
+	}
+}
+
+func TestExtractParameters_Suffix(t *testing.T) {
+	params := doExtractParams("/fixed/{var}_foo", 2, "/fixed/barrr_foo", t)
+	if params["var"] != "barrr" {
+		t.Errorf("parameter mismatch var")
+	}
+}
+
 func TestExtractParameters_RegexAndCustomVerb(t *testing.T) {
 	testCase := []struct{
 		route string

--- a/path_processor_test.go
+++ b/path_processor_test.go
@@ -1,6 +1,8 @@
 package restful
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMatchesPath_OneParam(t *testing.T) {
 	params := doExtractParams("/from/{source}", 2, "/from/here", t)
@@ -66,24 +68,24 @@ func TestExtractParameters_Suffix(t *testing.T) {
 }
 
 func TestExtractParameters_RegexAndCustomVerb(t *testing.T) {
-	testCase := []struct{
-		route string
-		size int
-		path string
+	testCase := []struct {
+		route     string
+		size      int
+		path      string
 		checkList map[string]string
 	}{
-		{"/projects/{projectId}/users/{id:^prefix-}:custom", 4,"/projects/110/users/prefix-userId:custom", map[string]string{
+		{"/projects/{projectId}/users/{id:^prefix-}:custom", 4, "/projects/110/users/prefix-userId:custom", map[string]string{
 			"projectId": "110",
-			"id":"prefix-userId",}},
-		{"/projects/{projectId}/users/{id:*}", 4,"/projects/110/users/prefix-userId:custom", map[string]string{
+			"id":        "prefix-userId"}},
+		{"/projects/{projectId}/users/{id:*}", 4, "/projects/110/users/prefix-userId:custom", map[string]string{
 			"projectId": "110",
-			"id":"prefix-userId:custom",}},
+			"id":        "prefix-userId:custom"}},
 	}
 
 	for idx, v := range testCase {
 		params := doExtractParams(v.route, v.size, v.path, t)
 		for k, val := range v.checkList {
-			if params[k] != val{
+			if params[k] != val {
 				t.Errorf("[%v] params: %v mismatch, expected: %v, actual: %v", idx, k, v.checkList[k], params[k])
 			}
 		}


### PR DESCRIPTION
In current implementation if you have a path parameter with some prefix or suffix the path processor doesn't extract the values correctly, see some examples:

```
/foo_{var}
/{var}_foo
/foo_{var}_bar
```

This patch handle those cases using regexp to correctly extract values.