### PR TITLE
Fix OpenAPI examples

### DIFF
--- a/examples/restful-openapi.go
+++ b/examples/restful-openapi.go
@@ -154,13 +154,17 @@ func enrichSwaggerObject(swo *spec.Swagger) {
 			Title:       "UserService",
 			Description: "Resource for managing Users",
 			Contact: &spec.ContactInfo{
-				Name:  "john",
-				Email: "john@doe.rp",
-				URL:   "http://johndoe.org",
+				ContactInfoProps: spec.ContactInfoProps{
+					Name:  "john",
+					Email: "john@doe.rp",
+					URL:   "http://johndoe.org",
+				},
 			},
 			License: &spec.License{
-				Name: "MIT",
-				URL:  "http://mit.org",
+				LicenseProps: spec.LicenseProps{
+					Name: "MIT",
+					URL:  "http://mit.org",
+				},
 			},
 			Version: "1.0.0",
 		},

--- a/examples/restful-user-resource.go
+++ b/examples/restful-user-resource.go
@@ -145,13 +145,17 @@ func enrichSwaggerObject(swo *spec.Swagger) {
 			Title:       "UserService",
 			Description: "Resource for managing Users",
 			Contact: &spec.ContactInfo{
-				Name:  "john",
-				Email: "john@doe.rp",
-				URL:   "http://johndoe.org",
+				ContactInfoProps: spec.ContactInfoProps{
+					Name:  "john",
+					Email: "john@doe.rp",
+					URL:   "http://johndoe.org",
+				},
 			},
 			License: &spec.License{
-				Name: "MIT",
-				URL:  "http://mit.org",
+				LicenseProps: spec.LicenseProps{
+					Name: "MIT",
+					URL:  "http://mit.org",
+				},
 			},
 			Version: "1.0.0",
 		},


### PR DESCRIPTION
There are breaking changes in go-openapi/spec#113.
This pull request fixes them.

```console
$ cd examples
$ go build restful-openapi.go
# command-line-arguments
.\restful-openapi.go:157:5: cannot use promoted field ContactInfoProps.Name in struct literal of type spec.ContactInfo
.\restful-openapi.go:158:5: cannot use promoted field ContactInfoProps.Email in struct literal of type spec.ContactInfo
.\restful-openapi.go:159:5: cannot use promoted field ContactInfoProps.URL in struct literal of type spec.ContactInfo
.\restful-openapi.go:162:5: cannot use promoted field LicenseProps.Name in struct literal of type spec.License
.\restful-openapi.go:163:5: cannot use promoted field LicenseProps.URL in struct literal of type spec.License
```