### PR TITLE
support describing response headers

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -176,6 +176,15 @@ func (b *RouteBuilder) Returns(code int, message string, model interface{}) *Rou
 	return b
 }
 
+// ReturnsWithHeaders is similar to Returns, but can specify response headers
+func (b *RouteBuilder) ReturnsWithHeaders(code int, message string, model interface{}, headers map[string]Header) *RouteBuilder {
+	b.Returns(code, message, model)
+	err := b.errorMap[code]
+	err.Headers = headers
+	b.errorMap[code] = err
+	return b
+}
+
 // DefaultReturns is a special Returns call that sets the default of the response.
 func (b *RouteBuilder) DefaultReturns(message string, model interface{}) *RouteBuilder {
 	b.defaultResponse = &ResponseError{
@@ -205,7 +214,25 @@ type ResponseError struct {
 	Code      int
 	Message   string
 	Model     interface{}
+	Headers   map[string]Header
 	IsDefault bool
+}
+
+// Header describes a header for a response of the API
+//
+// For more information: http://goo.gl/8us55a#headerObject
+type Header struct {
+	*Items
+	Description string
+}
+
+// Items describe swagger simple schemas for headers
+type Items struct {
+	Type             string
+	Format           string
+	Items            *Items
+	CollectionFormat string
+	Default          interface{}
 }
 
 func (b *RouteBuilder) servicePath(path string) *RouteBuilder {


### PR DESCRIPTION
Fixes #419 

In the OpenAPI Specification, response object has a headers field. (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responseObject)

But there is no field about headers in struct ResponseError. So I can not use code to describe the response header.

```go
type ResponseError struct {
	Code      int
	Message   string
	Model     interface{}
	IsDefault bool
}
```
I added the Headers field with reference to the OpenAPI Specification. And in order to maintain compatibility, I did not modify Returns method, but added a new method ReturnsWithHeaders.