### PR TITLE
405 Method Not Allowed must have Allow header

### DIFF
--- a/container.go
+++ b/container.go
@@ -185,6 +185,13 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 // when a ServiceError is returned during route selection. Default implementation
 // calls resp.WriteErrorString(err.Code, err.Message)
 func writeServiceError(err ServiceError, req *Request, resp *Response) {
+	if err.Header != nil {
+		for header, values := range err.Header {
+			for _, value := range values {
+				resp.Header().Add(header, value)
+			}
+		}
+	}
 	resp.WriteErrorString(err.Code, err.Message)
 }
 

--- a/container.go
+++ b/container.go
@@ -185,11 +185,9 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 // when a ServiceError is returned during route selection. Default implementation
 // calls resp.WriteErrorString(err.Code, err.Message)
 func writeServiceError(err ServiceError, req *Request, resp *Response) {
-	if err.Header != nil {
-		for header, values := range err.Header {
-			for _, value := range values {
-				resp.Header().Add(header, value)
-			}
+	for header, values := range err.Header {
+		for _, value := range values {
+			resp.Header().Add(header, value)
 		}
 	}
 	resp.WriteErrorString(err.Code, err.Message)

--- a/jsr311.go
+++ b/jsr311.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 )
 
 // RouterJSR311 implements the flow for matching Requests to Routes (and consequently Resource Functions)
@@ -98,7 +99,18 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 		if trace {
 			traceLogger.Printf("no Route found (in %d routes) that matches HTTP method %s\n", len(previous), httpRequest.Method)
 		}
-		return nil, NewError(http.StatusMethodNotAllowed, "405: Method Not Allowed")
+		allowed := []string{}
+	allowedLoop:
+		for _, candidate := range previous {
+			for _, method := range allowed {
+				if method == candidate.Method {
+					continue allowedLoop
+				}
+			}
+			allowed = append(allowed, candidate.Method)
+		}
+		header := http.Header{"Allowed": []string{strings.Join(allowed, ", ")}}
+		return nil, NewErrorWithHeader(http.StatusMethodNotAllowed, "405: Method Not Allowed", header)
 	}
 
 	// content-type

--- a/jsr311.go
+++ b/jsr311.go
@@ -109,7 +109,7 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 			}
 			allowed = append(allowed, candidate.Method)
 		}
-		header := http.Header{"Allowed": []string{strings.Join(allowed, ", ")}}
+		header := http.Header{"Allow": []string{strings.Join(allowed, ", ")}}
 		return nil, NewErrorWithHeader(http.StatusMethodNotAllowed, "405: Method Not Allowed", header)
 	}
 

--- a/service_error.go
+++ b/service_error.go
@@ -4,17 +4,26 @@ package restful
 // Use of this source code is governed by a license
 // that can be found in the LICENSE file.
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 // ServiceError is a transport object to pass information about a non-Http error occurred in a WebService while processing a request.
 type ServiceError struct {
 	Code    int
 	Message string
+	Header  http.Header
 }
 
 // NewError returns a ServiceError using the code and reason
 func NewError(code int, message string) ServiceError {
 	return ServiceError{Code: code, Message: message}
+}
+
+// NewErrorWithHeader returns a ServiceError using the code, reason and header
+func NewErrorWithHeader(code int, message string, header http.Header) ServiceError {
+	return ServiceError{Code: code, Message: message, Header: header}
 }
 
 // Error returns a text representation of the service error

--- a/web_service_test.go
+++ b/web_service_test.go
@@ -89,6 +89,21 @@ func TestMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestMethodNotAllowed_Issue435(t *testing.T) {
+	tearDown()
+	Add(newPutGetDeleteGetService())
+	httpRequest, _ := http.NewRequest("POST", "http://here/thing", nil)
+	httpRequest.Header.Set("Accept", "*/*")
+	httpWriter := httptest.NewRecorder()
+	DefaultContainer.dispatch(httpWriter, httpRequest)
+	if 405 != httpWriter.Code {
+		t.Error("405 expected method not allowed")
+	}
+	if "PUT, GET, DELETE" != httpWriter.Header().Get("Allowed") {
+		t.Error("405 expected Allowed header got ", httpWriter.Header())
+	}
+}
+
 func TestSelectedRoutePath_Issue100(t *testing.T) {
 	tearDown()
 	Add(newSelectedRouteTestingService())
@@ -273,6 +288,15 @@ func newPanicingService() *WebService {
 func newGetOnlyService() *WebService {
 	ws := new(WebService).Path("")
 	ws.Route(ws.GET("/get").To(doPanic))
+	return ws
+}
+
+func newPutGetDeleteGetService() *WebService {
+	ws := new(WebService).Path("")
+	ws.Route(ws.PUT("/thing").To(doPanic))
+	ws.Route(ws.GET("/thing").To(doPanic))
+	ws.Route(ws.DELETE("/thing").To(doPanic))
+	ws.Route(ws.GET("/other").To(doPanic))
 	return ws
 }
 

--- a/web_service_test.go
+++ b/web_service_test.go
@@ -91,7 +91,7 @@ func TestMethodNotAllowed(t *testing.T) {
 
 func TestMethodNotAllowed_Issue435(t *testing.T) {
 	tearDown()
-	Add(newPutGetDeleteGetService())
+	Add(newPutGetDeleteWithDuplicateService())
 	httpRequest, _ := http.NewRequest("POST", "http://here/thing", nil)
 	httpRequest.Header.Set("Accept", "*/*")
 	httpWriter := httptest.NewRecorder()
@@ -291,12 +291,12 @@ func newGetOnlyService() *WebService {
 	return ws
 }
 
-func newPutGetDeleteGetService() *WebService {
+func newPutGetDeleteWithDuplicateService() *WebService {
 	ws := new(WebService).Path("")
 	ws.Route(ws.PUT("/thing").To(doPanic))
 	ws.Route(ws.GET("/thing").To(doPanic))
 	ws.Route(ws.DELETE("/thing").To(doPanic))
-	ws.Route(ws.GET("/other").To(doPanic))
+	ws.Route(ws.GET("/thing").To(doPanic))
 	return ws
 }
 

--- a/web_service_test.go
+++ b/web_service_test.go
@@ -99,7 +99,7 @@ func TestMethodNotAllowed_Issue435(t *testing.T) {
 	if 405 != httpWriter.Code {
 		t.Error("405 expected method not allowed")
 	}
-	if "PUT, GET, DELETE" != httpWriter.Header().Get("Allowed") {
+	if "PUT, GET, DELETE" != httpWriter.Header().Get("Allow") {
 		t.Error("405 expected Allowed header got ", httpWriter.Header())
 	}
 }


### PR DESCRIPTION
The relevant specification says that 405 Method Not Allowed responses
MUST list allowed mthods in the Allow header:
https://tools.ietf.org/html/rfc7231#section-6.5.5
https://tools.ietf.org/html/rfc7231#section-7.4.1

fixes #435