### PR TITLE
Issue 471: Fix panic when removing a route that doesn't exist in w.routes.

### DIFF
--- a/web_service.go
+++ b/web_service.go
@@ -181,12 +181,12 @@ func (w *WebService) RemoveRoute(path, method string) error {
     }
     w.routesLock.Lock()
     defer w.routesLock.Unlock()
-    newRoutes := make([]Route, 0)
-    for ix := range w.routes {
-        if w.routes[ix].Method == method && w.routes[ix].Path == path {
+    newRoutes := []Route{}
+    for _, route := range w.routes {
+        if route.Method == method && route.Path == path {
             continue
         }
-        newRoutes = append(newRoutes, w.routes[ix])
+        newRoutes = append(newRoutes, route)
     }
     w.routes = newRoutes
     return nil

--- a/web_service.go
+++ b/web_service.go
@@ -176,22 +176,20 @@ func (w *WebService) Route(builder *RouteBuilder) *WebService {
 
 // RemoveRoute removes the specified route, looks for something that matches 'path' and 'method'
 func (w *WebService) RemoveRoute(path, method string) error {
-	if !w.dynamicRoutes {
-		return errors.New("dynamic routes are not enabled.")
-	}
-	w.routesLock.Lock()
-	defer w.routesLock.Unlock()
-	newRoutes := make([]Route, (len(w.routes) - 1))
-	current := 0
-	for ix := range w.routes {
-		if w.routes[ix].Method == method && w.routes[ix].Path == path {
-			continue
-		}
-		newRoutes[current] = w.routes[ix]
-		current++
-	}
-	w.routes = newRoutes
-	return nil
+    if !w.dynamicRoutes {
+        return errors.New("dynamic routes are not enabled.")
+    }
+    w.routesLock.Lock()
+    defer w.routesLock.Unlock()
+    newRoutes := make([]Route, 0)
+    for ix := range w.routes {
+        if w.routes[ix].Method == method && w.routes[ix].Path == path {
+            continue
+        }
+        newRoutes = append(newRoutes, w.routes[ix])
+    }
+    w.routes = newRoutes
+    return nil
 }
 
 // Method creates a new RouteBuilder and initialize its http method


### PR DESCRIPTION
This PR fixes the remaining panic in `RemoveRoute()`.