### PR TITLE
Fix broken link to UserResource example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 }
 ```
 	
-[Full API of a UserResource](https://github.com/emicklei/go-restful/tree/master/examples/restful-user-resource.go) 
+[Full API of a UserResource](https://github.com/emicklei/go-restful/blob/v3/examples/user-resource/restful-user-resource.go) 
 		
 ### Features
 


### PR DESCRIPTION
This will fix the broken link on the README.md which points to the `UserResource` example.