### PR TITLE
feat(parameter): adds additional openapi mappings

### DIFF
--- a/container.go
+++ b/container.go
@@ -287,7 +287,15 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 		allFilters = append(allFilters, c.containerFilters...)
 		allFilters = append(allFilters, webService.filters...)
 		allFilters = append(allFilters, route.Filters...)
-		chain := FilterChain{Filters: allFilters, Target: route.Function}
+		chain := FilterChain{
+			Filters: allFilters,
+			Target: func(req *Request, resp *Response) {
+				// handle request by route after passing all filters
+				route.Function(wrappedRequest, wrappedResponse)
+			},
+			ParameterDocs: route.ParameterDocs,
+			Operation:     route.Operation,
+		}
 		chain.ProcessFilter(wrappedRequest, wrappedResponse)
 	} else {
 		// no filters, handle request by route

--- a/filter.go
+++ b/filter.go
@@ -6,9 +6,11 @@ package restful
 
 // FilterChain is a request scoped object to process one or more filters before calling the target RouteFunction.
 type FilterChain struct {
-	Filters []FilterFunction // ordered list of FilterFunction
-	Index   int              // index into filters that is currently in progress
-	Target  RouteFunction    // function to call after passing all filters
+	Filters       []FilterFunction // ordered list of FilterFunction
+	Index         int              // index into filters that is currently in progress
+	Target        RouteFunction    // function to call after passing all filters
+	ParameterDocs []*Parameter     // the parameter docs for the route
+	Operation     string           // the name of the operation
 }
 
 // ProcessFilter passes the request,response pair through the next of Filters.

--- a/parameter.go
+++ b/parameter.go
@@ -58,8 +58,17 @@ type ParameterData struct {
 	Required                                bool
 	AllowableValues                         map[string]string
 	AllowMultiple                           bool
+	AllowEmptyValue                         bool
 	DefaultValue                            string
 	CollectionFormat                        string
+	Pattern                                 string
+	Minimum                                 *float64
+	Maximum                                 *float64
+	MinLength                               *int64
+	MaxLength                               *int64
+	MinItems                                *int64
+	MaxItems                                *int64
+	UniqueItems                             bool
 }
 
 // Data returns the state of the Parameter
@@ -107,6 +116,18 @@ func (p *Parameter) AllowMultiple(multiple bool) *Parameter {
 	return p
 }
 
+// AddExtension adds or updates a key=value pair to the extension map
+func (p *Parameter) AddExtension(key string, value interface{}) *Parameter {
+	p.data.AddExtension(key, value)
+	return p
+}
+
+// AllowEmptyValue sets the AllowEmptyValue field and returns the receiver
+func (p *Parameter) AllowEmptyValue(multiple bool) *Parameter {
+	p.data.AllowEmptyValue = multiple
+	return p
+}
+
 // AllowableValues sets the allowableValues field and returns the receiver
 func (p *Parameter) AllowableValues(values map[string]string) *Parameter {
 	p.data.AllowableValues = values
@@ -140,5 +161,53 @@ func (p *Parameter) Description(doc string) *Parameter {
 // CollectionFormat sets the collection format for an array type
 func (p *Parameter) CollectionFormat(format CollectionFormat) *Parameter {
 	p.data.CollectionFormat = format.String()
+	return p
+}
+
+// Pattern sets the pattern field and returns the receiver
+func (p *Parameter) Pattern(pattern string) *Parameter {
+	p.data.Pattern = pattern
+	return p
+}
+
+// Minimum sets the minimum field and returns the receiver
+func (p *Parameter) Minimum(minimum float64) *Parameter {
+	p.data.Minimum = &minimum
+	return p
+}
+
+// Maximum sets the maximum field and returns the receiver
+func (p *Parameter) Maximum(maximum float64) *Parameter {
+	p.data.Maximum = &maximum
+	return p
+}
+
+// MinLength sets the minLength field and returns the receiver
+func (p *Parameter) MinLength(minLength int64) *Parameter {
+	p.data.MinLength = &minLength
+	return p
+}
+
+// MaxLength sets the maxLength field and returns the receiver
+func (p *Parameter) MaxLength(maxLength int64) *Parameter {
+	p.data.MaxLength = &maxLength
+	return p
+}
+
+// MinItems sets the minItems field and returns the receiver
+func (p *Parameter) MinItems(minItems int64) *Parameter {
+	p.data.MinItems = &minItems
+	return p
+}
+
+// MaxItems sets the maxItems field and returns the receiver
+func (p *Parameter) MaxItems(maxItems int64) *Parameter {
+	p.data.MaxItems = &maxItems
+	return p
+}
+
+// UniqueItems sets the uniqueItems field and returns the receiver
+func (p *Parameter) UniqueItems(uniqueItems bool) *Parameter {
+	p.data.UniqueItems = uniqueItems
 	return p
 }


### PR DESCRIPTION
Adds the following OpenAPI features to parameter:
  - AllowEmptyValue
  - Pattern
  - Minimum
  - Maximum
  - MinLength
  - MaxLength
  - MinItems
  - MaxItems
  - UniqueItems

This also adds the operation name and route `ParameterDocs` to the `FilterChain` struct to allow filters access to both the operation name as well as the parameters defined for the requested route. Having this metadata allows filters to validate if a request is honoring the defined parameters.

This has additional changes to emicklei/go-restful-openapi#74 that would need to also be merged and released after this is.