### PR TITLE
FilterChain should pass the request and response from filters to Target function

### DIFF
--- a/container.go
+++ b/container.go
@@ -289,10 +289,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 		allFilters = append(allFilters, route.Filters...)
 		chain := FilterChain{
 			Filters: allFilters,
-			Target: func(req *Request, resp *Response) {
-				// handle request by route after passing all filters
-				route.Function(wrappedRequest, wrappedResponse)
-			},
+			Target: route.Function,
 			ParameterDocs: route.ParameterDocs,
 			Operation:     route.Operation,
 		}


### PR DESCRIPTION
The PR #478 brought some weird changes that breaks the filters behaviour.
We have a filter that creates another instance of Response to intercept all headers and data, then does an audit and modifies the data and only then it forwards to the original response.
But the lambda added in that PR breaks this logic, since the target function writes directly to the original response.