### PR TITLE
[Minor] Bad practice to have a mix of Receiver types.

### DIFF
--- a/route.go
+++ b/route.go
@@ -168,7 +168,7 @@ func tokenizePath(path string) []string {
 }
 
 // for debugging
-func (r Route) String() string {
+func (r *Route) String() string {
 	return r.Method + " " + r.Path
 }
 


### PR DESCRIPTION
I was using an old version and saw that 
```
r.contentEncodingEnabled = &enabled
```
Fix was added, however String() should be updated to also use a pointer receiver.

Per Golang Docs "In general, all methods on a given type should have either value or pointer receivers, but not a mixture of both."