### PR TITLE
use exact matching of allowed domain entries, issue #489 (#493)

### DIFF
--- a/cors_filter_test.go
+++ b/cors_filter_test.go
@@ -120,10 +120,46 @@ func TestCORSFilter_AllowedDomains(t *testing.T) {
 		DefaultContainer.Dispatch(httpWriter, httpRequest)
 		actual := httpWriter.Header().Get(HEADER_AccessControlAllowOrigin)
 		if actual != each.origin && each.allowed {
-			t.Fatal("expected to be accepted")
+			t.Error("expected to be accepted", each)
 		}
 		if actual == each.origin && !each.allowed {
-			t.Fatal("did not expect to be accepted")
+			t.Error("did not expect to be accepted")
 		}
+	}
+}
+
+func TestCORSFilter_AllowedDomainFunc(t *testing.T) {
+	cors := CrossOriginResourceSharing{
+		AllowedDomains: []string{"here", "there"},
+		AllowedDomainFunc: func(origin string) bool {
+			return "where" == origin
+		},
+	}
+	if got, want := cors.isOriginAllowed("here"), true; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+	if got, want := cors.isOriginAllowed("HERE"), true; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+	if got, want := cors.isOriginAllowed("there"), true; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+	if got, want := cors.isOriginAllowed("where"), true; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+	if got, want := cors.isOriginAllowed("nowhere"), false; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+	// just func
+	cors.AllowedDomains = []string{}
+	if got, want := cors.isOriginAllowed("here"), false; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+	if got, want := cors.isOriginAllowed("where"), true; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+	// empty domain
+	if got, want := cors.isOriginAllowed(""), false; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
 }


### PR DESCRIPTION
Backport #493 to fix #489 on the `v2` stream of `go-restful`.

Some GO projects might have indirect dependencies to the `v2` version of `emicklei/go-restful` so that upgrading to `v3.8.0` isn’t trivial.
See https://github.com/emicklei/go-restful/issues/489#issuecomment-1148861521.