### PR TITLE
Add test for client request with and without trailing slash.

### DIFF
--- a/web_service_test.go
+++ b/web_service_test.go
@@ -327,6 +327,28 @@ func TestOptionsShortcut(t *testing.T) {
 	}
 }
 
+func TestClientWithAndWithoutTrailingSlash(t *testing.T) {
+	tearDown()
+	ws := new(WebService).Path("/test")
+	ws.Route(ws.PUT("/").To(return200))
+	Add(ws)
+
+	for _, path := range []string{"http://here.com/test", "http://here.com/test/"} {
+		t.Run(path, func(t *testing.T) {
+			httpRequest, _ := http.NewRequest("PUT", path, nil)
+			httpRequest.Header.Set("Accept", "*/*")
+			httpWriter := httptest.NewRecorder()
+			// override the default here
+			DefaultContainer.DoNotRecover(false)
+			DefaultContainer.dispatch(httpWriter, httpRequest)
+			if 200 != httpWriter.Code {
+				body, _ := ioutil.ReadAll(httpWriter.Body)
+				t.Errorf("200 expected on test, got body: %s", string(body))
+			}
+		})
+	}
+}
+
 func newPanicingService() *WebService {
 	ws := new(WebService).Path("")
 	ws.Route(ws.GET("/fire").To(doPanic))


### PR DESCRIPTION
With #520 clients receive different responses depending on a trailing slash in the requested path. This did not matter before, so this was a breaking change.

I wrote a small reproducer test to show the difference before and after 05c4911f7a613dab429b2cb4b9837e08c2709335.

Is this expected behavior? It breaks quite a lot of our stuff. 🙈