### PR TITLE
fix misroute when dealing multiple webservice with regex

### DIFF
--- a/curly.go
+++ b/curly.go
@@ -161,9 +161,9 @@ func (c CurlyRouter) computeWebserviceScore(requestTokens []string, routeTokens 
 				return false, score
 			}
 
-			if colon := strings.Index(routeTokenItem, ":"); colon != -1 {
+			if colon := strings.Index(eachRouteToken, ":"); colon != -1 {
 				// match by regex
-				matchesToken, _ := c.regularMatchesPathToken(routeTokenItem, colon, requestTokenItem)
+				matchesToken, _ := c.regularMatchesPathToken(eachRouteToken, colon, eachRequestToken)
 				if matchesToken {
 					score++
 				}

--- a/curly.go
+++ b/curly.go
@@ -163,12 +163,9 @@ func (c CurlyRouter) computeWebserviceScore(requestTokens []string, routeTokens 
 
 			if colon := strings.Index(routeTokenItem, ":"); colon != -1 {
 				// match by regex
-				matchesToken, matchesRemainder := c.regularMatchesPathToken(routeTokenItem, colon, requestTokenItem)
+				matchesToken, _ := c.regularMatchesPathToken(routeTokenItem, colon, requestTokenItem)
 				if matchesToken {
 					score++
-				}
-				if matchesRemainder { // TODO research
-					score--
 				}
 			}
 

--- a/curly.go
+++ b/curly.go
@@ -160,7 +160,19 @@ func (c CurlyRouter) computeWebserviceScore(requestTokens []string, routeTokens 
 			if len(requestTokenItem) == 0 {
 				return false, score
 			}
-			score += 1
+
+			if colon := strings.Index(routeTokenItem, ":"); colon != -1 {
+				// match by regex
+				matchesToken, matchesRemainder := c.regularMatchesPathToken(routeTokenItem, colon, routeTokenItem)
+				if matchesToken {
+					score++
+				}
+				if matchesRemainder { // TODO research
+					score--
+				}
+			}
+
+			score++
 		} else {
 			// not a parameter
 			if requestTokenItem != routeTokenItem {

--- a/curly.go
+++ b/curly.go
@@ -46,10 +46,10 @@ func (c CurlyRouter) SelectRoute(
 // selectRoutes return a collection of Route from a WebService that matches the path tokens from the request.
 func (c CurlyRouter) selectRoutes(ws *WebService, requestTokens []string) sortableCurlyRoutes {
 	candidates := make(sortableCurlyRoutes, 0, 8)
-	for _, route := range ws.routes {
-		matches, paramCount, staticCount := c.matchesRouteByPathTokens(route.pathParts, requestTokens, route.hasCustomVerb)
+	for _, eachRoute := range ws.routes {
+		matches, paramCount, staticCount := c.matchesRouteByPathTokens(eachRoute.pathParts, requestTokens, eachRoute.hasCustomVerb)
 		if matches {
-			candidates.add(curlyRoute{route, paramCount, staticCount}) // TODO make sure Routes() return pointers?
+			candidates.add(curlyRoute{eachRoute, paramCount, staticCount}) // TODO make sure Routes() return pointers?
 		}
 	}
 	sort.Sort(candidates)
@@ -131,10 +131,10 @@ func (c CurlyRouter) detectRoute(candidateRoutes sortableCurlyRoutes, httpReques
 func (c CurlyRouter) detectWebService(requestTokens []string, webServices []*WebService) *WebService {
 	var bestWs *WebService
 	score := -1
-	for _, ws := range webServices {
-		matches, eachScore := c.computeWebserviceScore(requestTokens, ws.pathExpr.tokens)
+	for _, eachWS := range webServices {
+		matches, eachScore := c.computeWebserviceScore(requestTokens, eachWS.pathExpr.tokens)
 		if matches && (eachScore > score) {
-			bestWs = ws
+			bestWs = eachWS
 			score = eachScore
 		}
 	}
@@ -149,21 +149,21 @@ func (c CurlyRouter) computeWebserviceScore(requestTokens []string, routeTokens 
 	}
 	score := 0
 	for i := 0; i < len(routeTokens); i++ {
-		requestTokenItem := requestTokens[i]
-		routeTokenItem := routeTokens[i]
-		if len(requestTokenItem) == 0 && len(routeTokenItem) == 0 {
+		eachRequestToken := requestTokens[i]
+		eachRouteToken := routeTokens[i]
+		if len(eachRequestToken) == 0 && len(eachRouteToken) == 0 {
 			score++
 			continue
 		}
-		if len(routeTokenItem) > 0 && strings.HasPrefix(routeTokenItem, "{") {
+		if len(eachRouteToken) > 0 && strings.HasPrefix(eachRouteToken, "{") {
 			// no empty match
-			if len(requestTokenItem) == 0 {
+			if len(eachRequestToken) == 0 {
 				return false, score
 			}
 			score += 1
 		} else {
 			// not a parameter
-			if requestTokenItem != routeTokenItem {
+			if eachRequestToken != eachRouteToken {
 				return false, score
 			}
 			score += (len(routeTokens) - i) * 10 //fuzzy

--- a/curly.go
+++ b/curly.go
@@ -163,7 +163,7 @@ func (c CurlyRouter) computeWebserviceScore(requestTokens []string, routeTokens 
 
 			if colon := strings.Index(routeTokenItem, ":"); colon != -1 {
 				// match by regex
-				matchesToken, matchesRemainder := c.regularMatchesPathToken(routeTokenItem, colon, routeTokenItem)
+				matchesToken, matchesRemainder := c.regularMatchesPathToken(routeTokenItem, colon, requestTokenItem)
 				if matchesToken {
 					score++
 				}

--- a/curly.go
+++ b/curly.go
@@ -160,16 +160,15 @@ func (c CurlyRouter) computeWebserviceScore(requestTokens []string, routeTokens 
 			if len(eachRequestToken) == 0 {
 				return false, score
 			}
+			score++
 
 			if colon := strings.Index(eachRouteToken, ":"); colon != -1 {
 				// match by regex
 				matchesToken, _ := c.regularMatchesPathToken(eachRouteToken, colon, eachRequestToken)
 				if matchesToken {
-					score++
+					score++ // extra score for regex match
 				}
-			}
-
-			score++
+			}			
 		} else {
 			// not a parameter
 			if eachRequestToken != eachRouteToken {

--- a/curly_test.go
+++ b/curly_test.go
@@ -94,6 +94,26 @@ func Test_detectWebService(t *testing.T) {
 	}
 }
 
+func Test_detectWebServiceWithRegexPath(t *testing.T) {
+	router := CurlyRouter{}
+	holaWS := new(WebService).Path("/{:hola}")
+	helloWS := new(WebService).Path("/{:hello}")
+
+	var wss = []*WebService{holaWS, helloWS}
+
+	holaJuanInTokens := tokenizePath("/hola/juan")
+	selected := router.detectWebService(holaJuanInTokens, wss)
+	if selected != holaWS {
+		t.Fatalf("expected holaWS, got %v", selected.rootPath)
+	}
+
+	helloJuanInTokens := tokenizePath("/hello/juan")
+	selected = router.detectWebService(helloJuanInTokens, wss)
+	if selected != helloWS {
+		t.Fatalf("expected helloWS, got %v", selected.rootPath)
+	}
+}
+
 var routeMatchers = []struct {
 	route         string
 	path          string


### PR DESCRIPTION
feel pretty confident on this change: we skip regex tokens when detectWebService, but we still do regex match for each token on detectRoutes.

so there is no down side by doing extra regex match on detectWebService, and increase the score.

https://github.com/emicklei/go-restful/pull/548