### PR TITLE
  Add configurable regex caching for CurlyRouter path   tokens and custom verbs

### DIFF
--- a/curly.go
+++ b/curly.go
@@ -27,6 +27,17 @@ func SetPathTokenCacheEnabled(enabled bool) {
 	pathTokenCacheEnabled = enabled
 }
 
+// getCachedRegexp retrieves a compiled regex from the cache if found and valid.
+// Returns the regex and true if found and valid, nil and false otherwise.
+func getCachedRegexp(cache *sync.Map, pattern string) (*regexp.Regexp, bool) {
+	if cached, found := cache.Load(pattern); found {
+		if regex, ok := cached.(*regexp.Regexp); ok {
+			return regex, true
+		}
+	}
+	return nil, false
+}
+
 // SelectRoute is part of the Router interface and returns the best match
 // for the WebService and its Route for the given Request.
 func (c CurlyRouter) SelectRoute(
@@ -129,11 +140,9 @@ func (c CurlyRouter) regularMatchesPathToken(routeToken string, colon int, reque
 
 	// Check cache first (if enabled)
 	if pathTokenCacheEnabled {
-		if cached, found := regexCache.Load(regPart); found {
-			if regex, ok := cached.(*regexp.Regexp); ok {
-				matched := regex.MatchString(requestToken)
-				return matched, false
-			}
+		if regex, found := getCachedRegexp(&regexCache, regPart); found {
+			matched := regex.MatchString(requestToken)
+			return matched, false
 		}
 	}
 

--- a/curly.go
+++ b/curly.go
@@ -16,8 +16,16 @@ import (
 type CurlyRouter struct{}
 
 var (
-	regexCache sync.Map // Cache for compiled regex patterns
+	regexCache            sync.Map // Cache for compiled regex patterns
+	pathTokenCacheEnabled = true   // Enable/disable path token regex caching
 )
+
+// SetPathTokenCacheEnabled enables or disables path token regex caching for CurlyRouter.
+// When disabled, regex patterns will be compiled on every request.
+// When enabled (default), compiled regex patterns are cached for better performance.
+func SetPathTokenCacheEnabled(enabled bool) {
+	pathTokenCacheEnabled = enabled
+}
 
 // SelectRoute is part of the Router interface and returns the best match
 // for the WebService and its Route for the given Request.
@@ -118,20 +126,28 @@ func (c CurlyRouter) regularMatchesPathToken(routeToken string, colon int, reque
 		}
 		return true, true
 	}
-	
-	// Check cache first
-	if cached, found := regexCache.Load(regPart); found {
-		regex := cached.(*regexp.Regexp)
-		matched := regex.MatchString(requestToken)
-		return matched, false
+
+	// Check cache first (if enabled)
+	if pathTokenCacheEnabled {
+		if cached, found := regexCache.Load(regPart); found {
+			if regex, ok := cached.(*regexp.Regexp); ok {
+				matched := regex.MatchString(requestToken)
+				return matched, false
+			}
+		}
 	}
-	
-	// Compile and cache the regex
+
+	// Compile the regex
 	regex, err := regexp.Compile(regPart)
 	if err != nil {
 		return false, false
 	}
-	regexCache.Store(regPart, regex)
+
+	// Cache the regex (if enabled)
+	if pathTokenCacheEnabled {
+		regexCache.Store(regPart, regex)
+	}
+
 	matched := regex.MatchString(requestToken)
 	return matched, false
 }
@@ -187,7 +203,7 @@ func (c CurlyRouter) computeWebserviceScore(requestTokens []string, routeTokens 
 				if matchesToken {
 					score++ // extra score for regex match
 				}
-			}			
+			}
 		} else {
 			// not a parameter
 			if eachRequestToken != eachRouteToken {

--- a/curly.go
+++ b/curly.go
@@ -9,10 +9,15 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // CurlyRouter expects Routes with paths that contain zero or more parameters in curly brackets.
 type CurlyRouter struct{}
+
+var (
+	regexCache sync.Map // Cache for compiled regex patterns
+)
 
 // SelectRoute is part of the Router interface and returns the best match
 // for the WebService and its Route for the given Request.
@@ -113,8 +118,22 @@ func (c CurlyRouter) regularMatchesPathToken(routeToken string, colon int, reque
 		}
 		return true, true
 	}
-	matched, err := regexp.MatchString(regPart, requestToken)
-	return (matched && err == nil), false
+	
+	// Check cache first
+	if cached, found := regexCache.Load(regPart); found {
+		regex := cached.(*regexp.Regexp)
+		matched := regex.MatchString(requestToken)
+		return matched, false
+	}
+	
+	// Compile and cache the regex
+	regex, err := regexp.Compile(regPart)
+	if err != nil {
+		return false, false
+	}
+	regexCache.Store(regPart, regex)
+	matched := regex.MatchString(requestToken)
+	return matched, false
 }
 
 var jsr311Router = RouterJSR311{}

--- a/curly_test.go
+++ b/curly_test.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"io"
 	"net/http"
+	"sync"
 	"testing"
 )
 
@@ -262,3 +263,49 @@ func TestCurly_ISSUE_137_2(t *testing.T) {
 }
 
 func curlyDummy(req *Request, resp *Response) { io.WriteString(resp.ResponseWriter, "curlyDummy") }
+
+func TestRegexCaching(t *testing.T) {
+	// Clear cache before test
+	regexCache = sync.Map{}
+	
+	router := CurlyRouter{}
+	
+	// Test with regex pattern
+	routeToken := "{id:[0-9]+}"
+	requestToken := "123"
+	
+	// First call should cache the regex
+	matches1, _ := router.regularMatchesPathToken(routeToken, 3, requestToken)
+	if !matches1 {
+		t.Error("Expected first call to match")
+	}
+	
+	// Verify cache contains the pattern
+	pattern := "[0-9]+"
+	_, found := regexCache.Load(pattern)
+	if !found {
+		t.Error("Expected pattern to be cached")
+	}
+	
+	// Second call should use cached regex
+	matches2, _ := router.regularMatchesPathToken(routeToken, 3, requestToken)
+	if !matches2 {
+		t.Error("Expected second call to match using cache")
+	}
+	
+	// Test with different pattern to ensure separate caching
+	routeToken2 := "{name:[a-z]+}"
+	requestToken2 := "john"
+	
+	matches3, _ := router.regularMatchesPathToken(routeToken2, 5, requestToken2)
+	if !matches3 {
+		t.Error("Expected name pattern to match")
+	}
+	
+	// Verify both patterns are cached
+	pattern2 := "[a-z]+"
+	_, found2 := regexCache.Load(pattern2)
+	if !found2 {
+		t.Error("Expected name pattern to be cached")
+	}
+}

--- a/curly_test.go
+++ b/curly_test.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"io"
 	"net/http"
+	"regexp"
 	"sync"
 	"testing"
 )
@@ -265,6 +266,13 @@ func TestCurly_ISSUE_137_2(t *testing.T) {
 func curlyDummy(req *Request, resp *Response) { io.WriteString(resp.ResponseWriter, "curlyDummy") }
 
 func TestRegexCaching(t *testing.T) {
+	// Store original state and enable caching for this test
+	originalEnabled := pathTokenCacheEnabled
+	defer func() {
+		SetPathTokenCacheEnabled(originalEnabled)
+	}()
+	SetPathTokenCacheEnabled(true)
+	
 	// Clear cache before test
 	regexCache = sync.Map{}
 	
@@ -307,5 +315,85 @@ func TestRegexCaching(t *testing.T) {
 	_, found2 := regexCache.Load(pattern2)
 	if !found2 {
 		t.Error("Expected name pattern to be cached")
+	}
+}
+
+func TestRegexCacheDisabled(t *testing.T) {
+	// Store original state
+	originalEnabled := pathTokenCacheEnabled
+	defer func() {
+		SetPathTokenCacheEnabled(originalEnabled)
+	}()
+	
+	// Clear cache before test
+	regexCache = sync.Map{}
+	
+	// Disable caching
+	SetPathTokenCacheEnabled(false)
+	
+	router := CurlyRouter{}
+	routeToken := "{id:[0-9]+}"
+	requestToken := "123"
+	
+	// Call should work but not cache
+	matches, _ := router.regularMatchesPathToken(routeToken, 3, requestToken)
+	if !matches {
+		t.Error("Expected call to match")
+	}
+	
+	// Verify pattern is not cached
+	pattern := "[0-9]+"
+	_, found := regexCache.Load(pattern)
+	if found {
+		t.Error("Expected pattern to not be cached when caching is disabled")
+	}
+	
+	// Re-enable caching
+	SetPathTokenCacheEnabled(true)
+	
+	// Now it should cache
+	matches2, _ := router.regularMatchesPathToken(routeToken, 3, requestToken)
+	if !matches2 {
+		t.Error("Expected call to match")
+	}
+	
+	// Verify pattern is now cached
+	_, found2 := regexCache.Load(pattern)
+	if !found2 {
+		t.Error("Expected pattern to be cached when caching is re-enabled")
+	}
+}
+
+func TestRegexCachePanicSafety(t *testing.T) {
+	// Store original state
+	originalEnabled := pathTokenCacheEnabled
+	defer func() {
+		SetPathTokenCacheEnabled(originalEnabled)
+		regexCache = sync.Map{} // Clean up
+	}()
+	
+	SetPathTokenCacheEnabled(true)
+	
+	// Poison cache with wrong type
+	pattern := "[0-9]+"
+	regexCache.Store(pattern, "not a regex")
+	
+	router := CurlyRouter{}
+	routeToken := "{id:[0-9]+}"
+	requestToken := "123"
+	
+	// Should not panic, should handle invalid cache entry gracefully
+	matches, _ := router.regularMatchesPathToken(routeToken, 3, requestToken)
+	if !matches {
+		t.Error("Expected call to match even with corrupted cache")
+	}
+	
+	// After the call, the invalid entry should be overwritten with valid regex
+	if cached, found := regexCache.Load(pattern); found {
+		if _, ok := cached.(*regexp.Regexp); !ok {
+			t.Error("Expected invalid cache entry to be overwritten with valid regex")
+		}
+	} else {
+		t.Error("Expected valid regex to be cached")
 	}
 }

--- a/curly_test.go
+++ b/curly_test.go
@@ -390,7 +390,9 @@ func TestRegexCachePanicSafety(t *testing.T) {
 	
 	// After the call, the invalid entry should be overwritten with valid regex
 	if cached, found := regexCache.Load(pattern); found {
-		if _, ok := cached.(*regexp.Regexp); !ok {
+		if _, ok := cached.(*regexp.Regexp); ok {
+			// Success: cache entry is now a valid regex
+		} else {
 			t.Error("Expected invalid cache entry to be overwritten with valid regex")
 		}
 	} else {

--- a/custom_verb.go
+++ b/custom_verb.go
@@ -34,10 +34,8 @@ func isMatchCustomVerb(routeToken string, pathToken string) bool {
 
 	// Check cache first (if enabled)
 	if customVerbCacheEnabled {
-		if cached, found := customVerbCache.Load(regexPattern); found {
-			if specificVerbReg, ok := cached.(*regexp.Regexp); ok {
-				return specificVerbReg.MatchString(pathToken)
-			}
+		if specificVerbReg, found := getCachedRegexp(&customVerbCache, regexPattern); found {
+			return specificVerbReg.MatchString(pathToken)
 		}
 	}
 

--- a/custom_verb.go
+++ b/custom_verb.go
@@ -3,10 +3,12 @@ package restful
 import (
 	"fmt"
 	"regexp"
+	"sync"
 )
 
 var (
-	customVerbReg = regexp.MustCompile(":([A-Za-z]+)$")
+	customVerbReg   = regexp.MustCompile(":([A-Za-z]+)$")
+	customVerbCache sync.Map // Cache for compiled custom verb regexes
 )
 
 func hasCustomVerb(routeToken string) bool {
@@ -20,7 +22,17 @@ func isMatchCustomVerb(routeToken string, pathToken string) bool {
 	}
 
 	customVerb := rs[1]
-	specificVerbReg := regexp.MustCompile(fmt.Sprintf(":%s$", customVerb))
+	regexPattern := fmt.Sprintf(":%s$", customVerb)
+
+	// Check cache first
+	if cached, found := customVerbCache.Load(regexPattern); found {
+		specificVerbReg := cached.(*regexp.Regexp)
+		return specificVerbReg.MatchString(pathToken)
+	}
+
+	// Compile and cache the regex
+	specificVerbReg := regexp.MustCompile(regexPattern)
+	customVerbCache.Store(regexPattern, specificVerbReg)
 	return specificVerbReg.MatchString(pathToken)
 }
 

--- a/custom_verb.go
+++ b/custom_verb.go
@@ -7,9 +7,17 @@ import (
 )
 
 var (
-	customVerbReg   = regexp.MustCompile(":([A-Za-z]+)$")
-	customVerbCache sync.Map // Cache for compiled custom verb regexes
+	customVerbReg     = regexp.MustCompile(":([A-Za-z]+)$")
+	customVerbCache   sync.Map // Cache for compiled custom verb regexes
+	customVerbCacheEnabled = true // Enable/disable custom verb regex caching
 )
+
+// SetCustomVerbCacheEnabled enables or disables custom verb regex caching.
+// When disabled, custom verb regex patterns will be compiled on every request.
+// When enabled (default), compiled custom verb regex patterns are cached for better performance.
+func SetCustomVerbCacheEnabled(enabled bool) {
+	customVerbCacheEnabled = enabled
+}
 
 func hasCustomVerb(routeToken string) bool {
 	return customVerbReg.MatchString(routeToken)
@@ -24,15 +32,23 @@ func isMatchCustomVerb(routeToken string, pathToken string) bool {
 	customVerb := rs[1]
 	regexPattern := fmt.Sprintf(":%s$", customVerb)
 
-	// Check cache first
-	if cached, found := customVerbCache.Load(regexPattern); found {
-		specificVerbReg := cached.(*regexp.Regexp)
-		return specificVerbReg.MatchString(pathToken)
+	// Check cache first (if enabled)
+	if customVerbCacheEnabled {
+		if cached, found := customVerbCache.Load(regexPattern); found {
+			if specificVerbReg, ok := cached.(*regexp.Regexp); ok {
+				return specificVerbReg.MatchString(pathToken)
+			}
+		}
 	}
 
-	// Compile and cache the regex
+	// Compile the regex
 	specificVerbReg := regexp.MustCompile(regexPattern)
-	customVerbCache.Store(regexPattern, specificVerbReg)
+	
+	// Cache the regex (if enabled)
+	if customVerbCacheEnabled {
+		customVerbCache.Store(regexPattern, specificVerbReg)
+	}
+	
 	return specificVerbReg.MatchString(pathToken)
 }
 

--- a/custom_verb_test.go
+++ b/custom_verb_test.go
@@ -66,6 +66,13 @@ func TestMatchCustomVerb(t *testing.T) {
 }
 
 func TestCustomVerbCaching(t *testing.T) {
+	// Store original state and enable caching for this test
+	originalEnabled := customVerbCacheEnabled
+	defer func() {
+		SetCustomVerbCacheEnabled(originalEnabled)
+	}()
+	SetCustomVerbCacheEnabled(true)
+	
 	// Clear cache before test
 	customVerbCache = sync.Map{}
 	
@@ -105,5 +112,47 @@ func TestCustomVerbCaching(t *testing.T) {
 	_, found2 := customVerbCache.Load(pattern2)
 	if !found2 {
 		t.Error("Expected GET pattern to be cached")
+	}
+}
+
+func TestCustomVerbCacheDisabled(t *testing.T) {
+	// Store original state
+	originalEnabled := customVerbCacheEnabled
+	defer func() {
+		SetCustomVerbCacheEnabled(originalEnabled)
+	}()
+	
+	// Disable caching
+	SetCustomVerbCacheEnabled(false)
+	
+	routeToken := "{userId:regex}:DELETE"
+	pathToken := "user123:DELETE"
+	
+	// Call should work but not cache
+	result := isMatchCustomVerb(routeToken, pathToken)
+	if !result {
+		t.Error("Expected call to match")
+	}
+	
+	// Verify pattern is not cached
+	pattern := ":DELETE$"
+	_, found := customVerbCache.Load(pattern)
+	if found {
+		t.Error("Expected pattern to not be cached when caching is disabled")
+	}
+	
+	// Re-enable caching
+	SetCustomVerbCacheEnabled(true)
+	
+	// Now it should cache
+	result2 := isMatchCustomVerb(routeToken, pathToken)
+	if !result2 {
+		t.Error("Expected call to match")
+	}
+	
+	// Verify pattern is now cached
+	_, found2 := customVerbCache.Load(pattern)
+	if !found2 {
+		t.Error("Expected pattern to be cached when caching is re-enabled")
 	}
 }

--- a/custom_verb_test.go
+++ b/custom_verb_test.go
@@ -1,6 +1,9 @@
 package restful
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestHasCustomVerb(t *testing.T) {
 	testCase := []struct {
@@ -40,6 +43,7 @@ func TestRemoveCustomVerb(t *testing.T) {
 		}
 	}
 }
+
 func TestMatchCustomVerb(t *testing.T) {
 	testCase := []struct {
 		routeToken string
@@ -58,5 +62,48 @@ func TestMatchCustomVerb(t *testing.T) {
 		if rs != v.expected {
 			t.Errorf("expected value: %v, actual: %v, index: [%v]", v.expected, rs, idx)
 		}
+	}
+}
+
+func TestCustomVerbCaching(t *testing.T) {
+	// Clear cache before test
+	customVerbCache = sync.Map{}
+	
+	routeToken := "{userId:regex}:POST"
+	pathToken := "user123:POST"
+	
+	// First call should cache the regex
+	result1 := isMatchCustomVerb(routeToken, pathToken)
+	if !result1 {
+		t.Error("Expected first call to match")
+	}
+	
+	// Verify cache contains the pattern
+	pattern := ":POST$"
+	_, found := customVerbCache.Load(pattern)
+	if !found {
+		t.Error("Expected pattern to be cached")
+	}
+	
+	// Second call should use cached regex
+	result2 := isMatchCustomVerb(routeToken, pathToken)
+	if !result2 {
+		t.Error("Expected second call to match using cache")
+	}
+	
+	// Test with different verb to ensure separate caching
+	routeToken2 := "{userId:regex}:GET"
+	pathToken2 := "user123:GET"
+	
+	result3 := isMatchCustomVerb(routeToken2, pathToken2)
+	if !result3 {
+		t.Error("Expected GET verb to match")
+	}
+	
+	// Verify both patterns are cached
+	pattern2 := ":GET$"
+	_, found2 := customVerbCache.Load(pattern2)
+	if !found2 {
+		t.Error("Expected GET pattern to be cached")
 	}
 }


### PR DESCRIPTION
Adds optional regex pattern caching to improve CurlyRouter performance for applications with frequent path matching operations